### PR TITLE
Add FTM feature with autocalibration support, configured working for the TazPro.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -7,12 +7,12 @@
 
 /************** Uncomment a Tool Head Option From Below *********************/
 
-//#define TOOLHEAD_Legacy_Universal
-#define TOOLHEAD_Galaxy_Series
+#define TOOLHEAD_Legacy_Universal
+// #define TOOLHEAD_Galaxy_Series
 //#define TOOLHEAD_SL_SE_HE
 //#define TOOLHEAD_HS_HSPLUS
 //#define TOOLHEAD_H175
-//#define TOOLHEAD_M175
+#define TOOLHEAD_M175
 //#define TOOLHEAD_SK175
 //#define TOOLHEAD_SK285
 //#define TOOLHEAD_Quiver_DualExtruder            // TAZ Pro Dual Extruder

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -28,71 +28,66 @@
 #include "../../../module/ft_motion.h"
 #include "../../../module/stepper.h"
 
+
+#define CMPNSTR_IS_SHAPER(A) WITHIN(ftMotion.cfg.cmpnstr[A], ftMotionCmpnstr_ZV, ftMotionCmpnstr_MZV)
+#define CMPNSTR_IS_EISHAPER(A) WITHIN(ftMotion.cfg.cmpnstr[A], ftMotionCmpnstr_EI, ftMotionCmpnstr_3HEI)
+
+
 void say_shaping() {
   // FT Enabled
   SERIAL_ECHO_TERNARY(ftMotion.cfg.mode, "Fixed-Time Motion ", "en", "dis", "abled");
 
   // FT Shaping
   #if HAS_X_AXIS
-    if (ftMotion.cfg.mode > ftMotionMode_ENABLED) {
-      SERIAL_ECHOPGM(" with ");
-      switch (ftMotion.cfg.mode) {
+    if (CMPNSTR_IS_SHAPER(X_AXIS)) {
+      SERIAL_ECHOPGM(" with X/A axis ");
+      switch (ftMotion.cfg.cmpnstr[X_AXIS]) {
         default: break;
-        case ftMotionMode_ZV:    SERIAL_ECHOPGM("ZV");        break;
-        case ftMotionMode_ZVD:   SERIAL_ECHOPGM("ZVD");       break;
-        case ftMotionMode_ZVDD:  SERIAL_ECHOPGM("ZVDD");      break;
-        case ftMotionMode_ZVDDD: SERIAL_ECHOPGM("ZVDDD");     break;
-        case ftMotionMode_EI:    SERIAL_ECHOPGM("EI");        break;
-        case ftMotionMode_2HEI:  SERIAL_ECHOPGM("2 Hump EI"); break;
-        case ftMotionMode_3HEI:  SERIAL_ECHOPGM("3 Hump EI"); break;
-        case ftMotionMode_MZV:   SERIAL_ECHOPGM("MZV");       break;
-        //case ftMotionMode_DISCTF: SERIAL_ECHOPGM("discrete transfer functions"); break;
-        //case ftMotionMode_ULENDO_FBS: SERIAL_ECHOPGM("Ulendo FBS."); return;
+        case ftMotionCmpnstr_ZV:    SERIAL_ECHOPGM("ZV");        break;
+        case ftMotionCmpnstr_ZVD:   SERIAL_ECHOPGM("ZVD");       break;
+        case ftMotionCmpnstr_ZVDD:  SERIAL_ECHOPGM("ZVDD");      break;
+        case ftMotionCmpnstr_ZVDDD: SERIAL_ECHOPGM("ZVDDD");     break;
+        case ftMotionCmpnstr_EI:    SERIAL_ECHOPGM("EI");        break;
+        case ftMotionCmpnstr_2HEI:  SERIAL_ECHOPGM("2 Hump EI"); break;
+        case ftMotionCmpnstr_3HEI:  SERIAL_ECHOPGM("3 Hump EI"); break;
+        case ftMotionCmpnstr_MZV:   SERIAL_ECHOPGM("MZV");       break;
       }
       SERIAL_ECHOPGM(" shaping");
     }
+    #if HAS_Y_AXIS
+      if (CMPNSTR_IS_SHAPER(Y_AXIS)) {
+        SERIAL_ECHOPGM(" and with Y/B axis ");
+        switch (ftMotion.cfg.cmpnstr[Y_AXIS]) {
+          default: break;
+          case ftMotionCmpnstr_ZV:    SERIAL_ECHOPGM("ZV");        break;
+          case ftMotionCmpnstr_ZVD:   SERIAL_ECHOPGM("ZVD");       break;
+          case ftMotionCmpnstr_ZVDD:  SERIAL_ECHOPGM("ZVDD");      break;
+          case ftMotionCmpnstr_ZVDDD: SERIAL_ECHOPGM("ZVDDD");     break;
+          case ftMotionCmpnstr_EI:    SERIAL_ECHOPGM("EI");        break;
+          case ftMotionCmpnstr_2HEI:  SERIAL_ECHOPGM("2 Hump EI"); break;
+          case ftMotionCmpnstr_3HEI:  SERIAL_ECHOPGM("3 Hump EI"); break;
+          case ftMotionCmpnstr_MZV:   SERIAL_ECHOPGM("MZV");       break;
+        }
+        SERIAL_ECHOPGM(" shaping");
+      }
+    #endif
   #endif
   SERIAL_ECHOLNPGM(".");
 
-  const bool z_based = TERN0(HAS_DYNAMIC_FREQ_MM, ftMotion.cfg.dynFreqMode == dynFreqMode_Z_BASED),
-             g_based = TERN0(HAS_DYNAMIC_FREQ_G,  ftMotion.cfg.dynFreqMode == dynFreqMode_MASS_BASED),
-             dynamic = z_based || g_based;
-
-  // FT Dynamic Frequency Mode
-  if (ftMotion.cfg.modeHasShaper()) {
-    #if HAS_DYNAMIC_FREQ
-      SERIAL_ECHOPGM("Dynamic Frequency Mode ");
-      switch (ftMotion.cfg.dynFreqMode) {
-        default:
-        case dynFreqMode_DISABLED: SERIAL_ECHOPGM("disabled"); break;
-        #if HAS_DYNAMIC_FREQ_MM
-          case dynFreqMode_Z_BASED: SERIAL_ECHOPGM("Z-based"); break;
-        #endif
-        #if HAS_DYNAMIC_FREQ_G
-          case dynFreqMode_MASS_BASED: SERIAL_ECHOPGM("Mass-based"); break;
-        #endif
-      }
-      SERIAL_ECHOLNPGM(".");
-    #endif
-
-    #if HAS_X_AXIS
-      SERIAL_ECHO_TERNARY(dynamic, "X/A ", "base dynamic", "static", " compensator frequency: ");
+  #if HAS_X_AXIS
+    if (CMPNSTR_IS_SHAPER(X_AXIS)) {
+      SERIAL_ECHO( "X/A static compensator frequency: ");
       SERIAL_ECHO(p_float_t(ftMotion.cfg.baseFreq[X_AXIS], 2), F("Hz"));
-      #if HAS_DYNAMIC_FREQ
-        if (dynamic) SERIAL_ECHO(F(" scaling: "), p_float_t(ftMotion.cfg.dynFreqK[X_AXIS], 2), F("Hz/"), z_based ? F("mm") : F("g"));
-      #endif
       SERIAL_EOL();
-    #endif
-
+    }
     #if HAS_Y_AXIS
-      SERIAL_ECHO_TERNARY(dynamic, "Y/B ", "base dynamic", "static", " compensator frequency: ");
-      SERIAL_ECHO(p_float_t(ftMotion.cfg.baseFreq[Y_AXIS], 2), F(" Hz"));
-      #if HAS_DYNAMIC_FREQ
-        if (dynamic) SERIAL_ECHO(F(" scaling: "), p_float_t(ftMotion.cfg.dynFreqK[Y_AXIS], 2), F("Hz/"), z_based ? F("mm") : F("g"));
-      #endif
-      SERIAL_EOL();
+      if (CMPNSTR_IS_SHAPER(Y_AXIS)) {
+        SERIAL_ECHO( "Y/B static compensator frequency: ");
+        SERIAL_ECHO(p_float_t(ftMotion.cfg.baseFreq[Y_AXIS], 2), F("Hz"));
+        SERIAL_EOL();
+      }
     #endif
-  }
+  #endif  
 
   #if HAS_EXTRUDERS
     SERIAL_ECHO_TERNARY(ftMotion.cfg.linearAdvEna, "Linear Advance ", "en", "dis", "abled");
@@ -104,6 +99,8 @@ void say_shaping() {
 }
 
 void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_FT_MOTION));
   const ft_config_t &c = ftMotion.cfg;
   SERIAL_ECHOPGM("  M493 S", c.mode);
@@ -111,15 +108,6 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
     SERIAL_ECHOPGM(" A", c.baseFreq[X_AXIS]);
     #if HAS_Y_AXIS
       SERIAL_ECHOPGM(" B", c.baseFreq[Y_AXIS]);
-    #endif
-  #endif
-  #if HAS_DYNAMIC_FREQ
-    SERIAL_ECHOPGM(" D", c.dynFreqMode);
-    #if HAS_X_AXIS
-      SERIAL_ECHOPGM(" F", c.dynFreqK[X_AXIS]);
-      #if HAS_Y_AXIS
-        SERIAL_ECHOPGM(" H", c.dynFreqK[Y_AXIS]);
-      #endif
     #endif
   #endif
   #if HAS_EXTRUDERS
@@ -131,40 +119,37 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
 /**
  * M493: Set Fixed-time Motion Control parameters
  *
- *    S<mode> Set the motion / shaping mode. Shaping requires an X axis, at the minimum.
+ *    S<mode> Enable / disable the use of fixed time motion.
  *
  *       0: Standard Motion
  *       1: Fixed-Time Motion
- *      10: ZV    : Zero Vibration
- *      11: ZVD   : Zero Vibration and Derivative
- *      12: ZVDD  : Zero Vibration, Derivative, and Double Derivative
- *      13: ZVDDD : Zero Vibration, Derivative, Double Derivative, and Triple Derivative
- *      14: EI    : Extra-Intensive
- *      15: 2HEI  : 2-Hump Extra-Intensive
- *      16: 3HEI  : 3-Hump Extra-Intensive
- *      17: MZV   : Mass-based Zero Vibration
+ * 
+ *    X/Y<compensator mode> Set the vibration compensator [input shaper] mode of the X and
+ *                          Y axes respectively. Requires an X axis, at the minimum.
+ *      0: None
+ *      1: ZV    : Zero Vibration
+ *      2: ZVD   : Zero Vibration and Derivative
+ *      3: ZVDD  : Zero Vibration, Derivative, and Double Derivative
+ *      4: ZVDDD : Zero Vibration, Derivative, Double Derivative, and Triple Derivative
+ *      5: EI    : Extra-Intensive
+ *      6: 2HEI  : 2-Hump Extra-Intensive
+ *      7: 3HEI  : 3-Hump Extra-Intensive
+ *      8: MZV   : Mass-based Zero Vibration
  *
  *    P<bool> Enable (1) or Disable (0) Linear Advance pressure control
  *
  *    K<gain> Set Linear Advance gain
  *
- *    D<mode> Set Dynamic Frequency mode
- *       0: DISABLED
- *       1: Z-based (Requires a Z axis)
- *       2: Mass-based (Requires X and E axes)
- *
  *    A<Hz>   Set static/base frequency for the X axis
- *    F<Hz>   Set frequency scaling for the X axis
  *    I 0.0   Set damping ratio for the X axis
  *    Q 0.00  Set the vibration tolerance for the X axis
  *
  *    B<Hz> Set static/base frequency for the Y axis
- *    H<Hz> Set frequency scaling for the Y axis
  *    J 0.0   Set damping ratio for the Y axis
  *    R 0.00  Set the vibration tolerance for the Y axis
  */
 void GcodeSuite::M493() {
-  struct { bool update_n:1, update_a:1, reset_ft:1, report_h:1; } flag = { false };
+  struct { bool update_shpr_params:1, reset_ft:1, report_h:1; } flag = { false };
 
   if (!parser.seen_any())
     flag.report_h = true;
@@ -176,19 +161,6 @@ void GcodeSuite::M493() {
     if (newmm != ftMotion.cfg.mode) {
       switch (newmm) {
         default: SERIAL_ECHOLNPGM("?Invalid control mode [S] value."); return;
-        #if HAS_X_AXIS
-          case ftMotionMode_ZV:
-          case ftMotionMode_ZVD:
-          case ftMotionMode_ZVDD:
-          case ftMotionMode_ZVDDD:
-          case ftMotionMode_EI:
-          case ftMotionMode_2HEI:
-          case ftMotionMode_3HEI:
-          case ftMotionMode_MZV:
-          //case ftMotionMode_ULENDO_FBS:
-          //case ftMotionMode_DISCTF:
-            flag.update_n = flag.update_a = true;
-        #endif
         case ftMotionMode_DISABLED: flag.reset_ft = true;
         case ftMotionMode_ENABLED:
           ftMotion.cfg.mode = newmm;
@@ -197,6 +169,60 @@ void GcodeSuite::M493() {
       }
     }
   }
+
+  
+  #if HAS_X_AXIS
+    // Parse 'X' mode parameter.
+    if (parser.seenval('X')) {
+      const ftMotionCmpnstr_t newmm = (ftMotionCmpnstr_t)parser.value_byte();
+
+      if (newmm != ftMotion.cfg.cmpnstr[X_AXIS]) {
+        switch (newmm) {
+          default: SERIAL_ECHOLNPGM("?Invalid compensator / shaper [X] value."); return;
+          case ftMotionCmpnstr_NONE:
+          case ftMotionCmpnstr_ZV:
+          case ftMotionCmpnstr_ZVD:
+          case ftMotionCmpnstr_ZVDD:
+          case ftMotionCmpnstr_ZVDDD:
+          case ftMotionCmpnstr_EI:
+          case ftMotionCmpnstr_2HEI:
+          case ftMotionCmpnstr_3HEI:
+          case ftMotionCmpnstr_MZV:
+            flag.update_shpr_params = true;
+            ftMotion.cfg.cmpnstr[X_AXIS] = newmm;
+            flag.report_h = true;
+            break;
+        }
+      }
+    }
+
+    #if HAS_Y_AXIS
+      // Parse 'Y' mode parameter.
+      if (parser.seenval('Y')) {
+        const ftMotionCmpnstr_t newmm = (ftMotionCmpnstr_t)parser.value_byte();
+
+        if (newmm != ftMotion.cfg.cmpnstr[Y_AXIS]) {
+          switch (newmm) {
+            default: SERIAL_ECHOLNPGM("?Invalid compensator / shaper [Y] value."); return;
+            case ftMotionCmpnstr_NONE:
+            case ftMotionCmpnstr_ZV:
+            case ftMotionCmpnstr_ZVD:
+            case ftMotionCmpnstr_ZVDD:
+            case ftMotionCmpnstr_ZVDDD:
+            case ftMotionCmpnstr_EI:
+            case ftMotionCmpnstr_2HEI:
+            case ftMotionCmpnstr_3HEI:
+            case ftMotionCmpnstr_MZV:
+              flag.update_shpr_params = true;
+              ftMotion.cfg.cmpnstr[Y_AXIS] = newmm;
+              flag.report_h = true;
+              break;
+          }
+        }
+      }
+    #endif
+  #endif
+
 
   #if HAS_EXTRUDERS
 
@@ -221,50 +247,16 @@ void GcodeSuite::M493() {
 
   #endif // HAS_EXTRUDERS
 
-  #if HAS_DYNAMIC_FREQ
-
-    // Dynamic frequency mode parameter.
-    if (parser.seenval('D')) {
-      if (ftMotion.cfg.modeHasShaper()) {
-        const dynFreqMode_t val = dynFreqMode_t(parser.value_byte());
-        switch (val) {
-          #if HAS_DYNAMIC_FREQ_MM
-            case dynFreqMode_Z_BASED:
-          #endif
-          #if HAS_DYNAMIC_FREQ_G
-            case dynFreqMode_MASS_BASED:
-          #endif
-          case dynFreqMode_DISABLED:
-            ftMotion.cfg.dynFreqMode = val;
-            flag.report_h = true;
-            break;
-          default:
-            SERIAL_ECHOLNPGM("?Invalid Dynamic Frequency Mode [D] value.");
-            break;
-        }
-      }
-      else {
-        SERIAL_ECHOLNPGM("?Wrong shaper for [D] Dynamic Frequency mode.");
-      }
-    }
-
-    const bool modeUsesDynFreq = (
-         TERN0(HAS_DYNAMIC_FREQ_MM, ftMotion.cfg.dynFreqMode == dynFreqMode_Z_BASED)
-      || TERN0(HAS_DYNAMIC_FREQ_G,  ftMotion.cfg.dynFreqMode == dynFreqMode_MASS_BASED)
-    );
-
-  #endif // HAS_DYNAMIC_FREQ
-
   #if HAS_X_AXIS
 
     // Parse frequency parameter (X axis).
     if (parser.seenval('A')) {
-      if (ftMotion.cfg.modeHasShaper()) {
+      if (CMPNSTR_IS_SHAPER(X_AXIS)) {
         const float val = parser.value_float();
         // TODO: Frequency minimum is dependent on the shaper used; the above check isn't always correct.
         if (WITHIN(val, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2)) {
           ftMotion.cfg.baseFreq[X_AXIS] = val;
-          flag.update_n = flag.reset_ft = flag.report_h = true;
+          flag.update_shpr_params = flag.reset_ft = flag.report_h = true;
         }
         else // Frequency out of range.
           SERIAL_ECHOLNPGM("Invalid [", C('A'), "] frequency value.");
@@ -273,25 +265,13 @@ void GcodeSuite::M493() {
         SERIAL_ECHOLNPGM("Wrong mode for [", C('A'), "] frequency.");
     }
 
-    #if HAS_DYNAMIC_FREQ
-      // Parse frequency scaling parameter (X axis).
-      if (parser.seenval('F')) {
-        if (modeUsesDynFreq) {
-          ftMotion.cfg.dynFreqK[X_AXIS] = parser.value_float();
-          flag.report_h = true;
-        }
-        else
-          SERIAL_ECHOLNPGM("Wrong mode for [", C('F'), "] frequency scaling.");
-      }
-    #endif
-
     // Parse zeta parameter (X axis).
     if (parser.seenval('I')) {
       const float val = parser.value_float();
-      if (ftMotion.cfg.modeHasShaper()) {
+      if (CMPNSTR_IS_SHAPER(X_AXIS)) {
         if (WITHIN(val, 0.01f, 1.0f)) {
           ftMotion.cfg.zeta[0] = val;
-          flag.update_n = flag.update_a = true;
+          flag.update_shpr_params = true;
         }
         else
           SERIAL_ECHOLNPGM("Invalid X zeta [", C('I'), "] value."); // Zeta out of range.
@@ -303,10 +283,10 @@ void GcodeSuite::M493() {
     // Parse vtol parameter (X axis).
     if (parser.seenval('Q')) {
       const float val = parser.value_float();
-      if (ftMotion.cfg.modeHasShaper() && IS_EI_MODE(ftMotion.cfg.mode)) {
+      if (CMPNSTR_IS_EISHAPER(X_AXIS)) {
         if (WITHIN(val, 0.00f, 1.0f)) {
           ftMotion.cfg.vtol[0] = val;
-          flag.update_a = true;
+          flag.update_shpr_params = true;
         }
         else
           SERIAL_ECHOLNPGM("Invalid X vtol [", C('Q'), "] value."); // VTol out of range.
@@ -321,11 +301,11 @@ void GcodeSuite::M493() {
 
     // Parse frequency parameter (Y axis).
     if (parser.seenval('B')) {
-      if (ftMotion.cfg.modeHasShaper()) {
+      if (CMPNSTR_IS_SHAPER(Y_AXIS)) {
         const float val = parser.value_float();
         if (WITHIN(val, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2)) {
           ftMotion.cfg.baseFreq[Y_AXIS] = val;
-          flag.update_n = flag.reset_ft = flag.report_h = true;
+          flag.update_shpr_params = flag.reset_ft = flag.report_h = true;
         }
         else // Frequency out of range.
           SERIAL_ECHOLNPGM("Invalid frequency [", C('B'), "] value.");
@@ -334,25 +314,13 @@ void GcodeSuite::M493() {
         SERIAL_ECHOLNPGM("Wrong mode for [", C('B'), "] frequency.");
     }
 
-    #if HAS_DYNAMIC_FREQ
-      // Parse frequency scaling parameter (Y axis).
-      if (parser.seenval('H')) {
-        if (modeUsesDynFreq) {
-          ftMotion.cfg.dynFreqK[Y_AXIS] = parser.value_float();
-          flag.report_h = true;
-        }
-        else
-          SERIAL_ECHOLNPGM("Wrong mode for [", C('H'), "] frequency scaling.");
-      }
-    #endif
-
     // Parse zeta parameter (Y axis).
     if (parser.seenval('J')) {
       const float val = parser.value_float();
-      if (ftMotion.cfg.modeHasShaper()) {
+      if (CMPNSTR_IS_SHAPER(Y_AXIS)) {
         if (WITHIN(val, 0.01f, 1.0f)) {
           ftMotion.cfg.zeta[1] = val;
-          flag.update_n = flag.update_a = true;
+          flag.update_shpr_params = true;
         }
         else
           SERIAL_ECHOLNPGM("Invalid Y zeta [", C('J'), "] value."); // Zeta Out of range
@@ -364,10 +332,10 @@ void GcodeSuite::M493() {
     // Parse vtol parameter (Y axis).
     if (parser.seenval('R')) {
       const float val = parser.value_float();
-      if (ftMotion.cfg.modeHasShaper() && IS_EI_MODE(ftMotion.cfg.mode)) {
+      if (CMPNSTR_IS_EISHAPER(Y_AXIS)) {
         if (WITHIN(val, 0.00f, 1.0f)) {
           ftMotion.cfg.vtol[1] = val;
-          flag.update_a = true;
+          flag.update_shpr_params = true;
         }
         else
           SERIAL_ECHOLNPGM("Invalid Y vtol [", C('R'), "] value."); // VTol out of range.
@@ -380,9 +348,7 @@ void GcodeSuite::M493() {
 
   planner.synchronize();
 
-  if (flag.update_n) ftMotion.refreshShapingN();
-
-  if (flag.update_a) ftMotion.updateShapingA();
+  if (flag.update_shpr_params) ftMotion.update_shaping_params();
 
   if (flag.reset_ft) {
     stepper.ftMotion_syncPosition();

--- a/Marlin/src/gcode/feature/ft_motion/M494.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M494.cpp
@@ -1,0 +1,211 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if ENABLED(FT_MOTION)
+
+#include "../../gcode.h"
+#include "../../../module/ft_motion.h"
+#include "../../../module/stepper.h"
+
+
+void say_ftm_cfg() {
+  #if ENABLED(FTM_UNIFIED_BWS)
+    SERIAL_ECHOPGM( "M494 FTMCFG FTM_BATCH_SIZE:", (int)(FTM_BW_SIZE),
+                    " FTM_WINDOW_SIZE:", (int)(FTM_BW_SIZE));
+  #else
+    SERIAL_ECHOPGM( "M494 FTMCFG FTM_BATCH_SIZE:", (int)(FTM_BATCH_SIZE),
+                    " FTM_WINDOW_SIZE:", (int)(FTM_WINDOW_SIZE));
+  #endif
+  SERIAL_ECHOPGM( " FTM_FS:", (int)(FTM_FS),
+                  " FTM_STEPPER_FS:", (int)(FTM_STEPPER_FS),
+                  " FTM_STEPPERCMD_BUFF_SIZE:", (int)(FTM_STEPPERCMD_BUFF_SIZE),
+                  " STEPPER_TIMER_RATE:", (int)(STEPPER_TIMER_RATE),
+                  " FTM_ZMAX:", (int)(FTM_ZMAX),
+                  " X_MAX_LENGTH:", (int)(X_MAX_LENGTH));
+  #if HAS_Y_AXIS
+    SERIAL_ECHOPGM( " Y_MAX_LENGTH:", (int)(Y_MAX_LENGTH));
+  #endif
+  SERIAL_EOL();
+}
+
+
+/**
+ * M494: Interact with Fixed-time Motion Control's trajectory generation.
+ *
+ *    A<mode> Start / abort a frequency sweep profile.
+ *
+ *       0: None active.
+ *       1: Continuous sweep on X axis.
+ *       2: Continuous sweep on Y axis.
+ *       99: Abort the current sweep.
+ * 
+ *    B<float> Start frequency.
+ *    C<float> End frequency.
+ *    D<float> Frequency rate.
+ *    E<float> Acceleration amplitude.
+ *    F<float> Step time.
+ *    H<float> Step acceleration amplitude.
+ *    I<float> Delay time to opening step.
+ *    J<float> Delay time from opening step to sweep.
+ *    K<float> Delay time from sweep to closing step.
+ * 
+ * With no parameters passed, M494 will report the FTM configuration and
+ * variables required for autocalibration.
+ * 
+ */
+void GcodeSuite::M494() {
+  
+  if (!parser.seen_any()) { say_ftm_cfg(); return; }
+
+  if (!ftMotion.cfg.mode) { SERIAL_ECHOLN("M494 echo: rejected! FTM is not enabled."); return; }
+
+  ftMotionTrajGenMode_t mode_val_seen = trajGenMode_NONE;
+  bool good_cfg_received = true;
+
+  // Parse mode parameter.
+  if (parser.seenval('A')) {
+    const ftMotionTrajGenMode_t newmm = (ftMotionTrajGenMode_t)parser.value_byte();
+    switch (newmm) {
+      default: SERIAL_ECHOLNPGM("?Invalid calibration mode [F] value."); return;
+      case trajGenMode_NONE:
+      case trajGenMode_SWEEPC_X:
+      #if HAS_Y_AXIS
+      case trajGenMode_SWEEPC_Y:
+      #endif
+        if ( ftMotion.traj_gen_cfg.mode ) {
+          SERIAL_ECHOLN("M494 echo: rejected! wait for the previous command to complete.");
+          return;
+        }
+        mode_val_seen = newmm;
+        break;
+      case trajGenMode_ABORT:
+        if ( ftMotion.traj_gen_cfg.mode ) {
+          ftMotion.traj_gen_cfg.mode = trajGenMode_NONE;
+          stepper.quick_stop();
+          return;
+        }
+    }
+  }
+
+  // Parse start frequency parameter.
+  if (parser.seenval('B')) {
+      const float val = parser.value_float();
+      if (val >= 1.0f) ftMotion.traj_gen_cfg.f0 = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Start frequency out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse end frequency parameter.
+  if (parser.seenval('C')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.f1 = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: End frequency out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse step frequency parameter.
+  if (parser.seenval('D')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dfdt = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Step / delta frequency out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse amplitude parameter.
+  if (parser.seenval('E')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.a = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Amplitude out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse step time parameter.
+  if (parser.seenval('F')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.step_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Step time out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse step amplitude parameter.
+  if (parser.seenval('H')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.step_a = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Step amplitude out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse delay parameter.
+  if (parser.seenval('I')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dly1_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Delay 1 out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse delay parameter.
+  if (parser.seenval('J')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dly2_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Delay 2 out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse delay parameter.
+  if (parser.seenval('K')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dly3_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Delay 3 out of range."); }
+  } else good_cfg_received = false;
+
+  // Validate and set.
+  if ( mode_val_seen && good_cfg_received ) {
+
+    planner.synchronize();
+
+    const float f0_ = ftMotion.traj_gen_cfg.f0 - 1.f; // This is calculated assuming a ramp time of 1 sec.
+
+    ftMotion.traj_gen_cfg.k1 = PI*ftMotion.traj_gen_cfg.dfdt;
+    ftMotion.traj_gen_cfg.k2 = 2.f*PI*f0_;
+
+    ftMotion.traj_gen_cfg.pcws_ti[0] = ftMotion.traj_gen_cfg.dly1_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[1] = ftMotion.traj_gen_cfg.pcws_ti[0] + 4 * ftMotion.traj_gen_cfg.step_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[2] = ftMotion.traj_gen_cfg.pcws_ti[1] + ftMotion.traj_gen_cfg.dly2_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[3] = ftMotion.traj_gen_cfg.pcws_ti[2] + ( ftMotion.traj_gen_cfg.f1 - f0_ ) / ftMotion.traj_gen_cfg.dfdt;
+    ftMotion.traj_gen_cfg.pcws_ti[4] = ftMotion.traj_gen_cfg.pcws_ti[3] + ftMotion.traj_gen_cfg.dly3_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[5] = ftMotion.traj_gen_cfg.pcws_ti[4] + 4 * ftMotion.traj_gen_cfg.step_ti;
+
+    ftMotion.traj_gen_cfg.step_a_x_0p5 = 0.5f * ftMotion.traj_gen_cfg.step_a;
+    ftMotion.traj_gen_cfg.step_a_x_step_ti_x_step_ti = ftMotion.traj_gen_cfg.step_a * sq(ftMotion.traj_gen_cfg.step_ti);
+    ftMotion.traj_gen_cfg.step_ti_x_2 = 2.f * ftMotion.traj_gen_cfg.step_ti;
+    ftMotion.traj_gen_cfg.step_ti_x_3 = 3.f * ftMotion.traj_gen_cfg.step_ti;
+    ftMotion.traj_gen_cfg.step_ti_x_4 = 4.f * ftMotion.traj_gen_cfg.step_ti;
+
+    ftMotion.traj_gen_cfg.mode = mode_val_seen;
+
+    ftMotion.setup_traj_gen(round(ftMotion.traj_gen_cfg.pcws_ti[5]*FTM_FS + 0.5f));
+
+    SERIAL_ECHOLN("M494 echo: SWEEPC starting.");
+
+    stepper.enable_all_steppers();
+
+    // stepper.disable_all_steppers(); Leave this to the plugin or user; this can
+    // be annoying on printers that require all axes homing before axis movement.
+  }
+
+}
+
+#endif // FT_MOTION

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -907,6 +907,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
       #if ENABLED(FT_MOTION)
         case 493: M493(); break;                                  // M493: Fixed-Time Motion control
+        case 494: M494(); break;                                  // M494: Fixed-Time Motion control trajectory generation
       #endif
 
       case 500: M500(); break;                                    // M500: Store settings in EEPROM

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -1070,6 +1070,7 @@ private:
   #if ENABLED(FT_MOTION)
     static void M493();
     static void M493_report(const bool forReplay=true);
+    static void M494();
   #endif
 
   static void M500();

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -50,6 +50,10 @@
   #include "../feature/joystick.h"
 #endif
 
+#if ENABLED(FT_MOTION)
+  #include "ft_motion.h"
+#endif
+
 #if HAS_BED_PROBE
   #include "probe.h"
 #endif
@@ -795,9 +799,18 @@ void Endstops::update() {
 
   // Signal, after validation, if an endstop limit is pressed or not
 
+  bool x_moving, x_neg_dir;
   #if HAS_X_AXIS
-    if (stepper.axis_is_moving(X_AXIS)) {
-      if (!stepper.motor_direction(X_AXIS_HEAD)) { // -direction
+    if (ftMotion.cfg.mode) {
+      const bool x_moving_pos = ftMotion.axis_moving_pos(X_AXIS_HEAD);
+      x_neg_dir = ftMotion.axis_moving_neg(X_AXIS_HEAD);
+      x_moving = x_moving_pos || x_neg_dir;
+    } else {
+      x_neg_dir = !stepper.motor_direction(X_AXIS_HEAD);
+      x_moving = stepper.axis_is_moving(X_AXIS);
+    }
+    if (x_moving) {
+      if (x_neg_dir) { // -direction
         #if HAS_X_MIN_STATE
           PROCESS_ENDSTOP_X(MIN);
           #if   CORE_DIAG(XY, Y, MIN)
@@ -828,9 +841,18 @@ void Endstops::update() {
     }
   #endif // HAS_X_AXIS
 
+  bool y_moving, y_neg_dir;
   #if HAS_Y_AXIS
-    if (stepper.axis_is_moving(Y_AXIS)) {
-      if (!stepper.motor_direction(Y_AXIS_HEAD)) { // -direction
+    if (ftMotion.cfg.mode) {
+      const bool y_moving_pos = ftMotion.axis_moving_pos(Y_AXIS_HEAD);
+      y_neg_dir = ftMotion.axis_moving_neg(Y_AXIS_HEAD);
+      y_moving = y_moving_pos || y_neg_dir;
+    } else {
+      y_neg_dir = !stepper.motor_direction(Y_AXIS_HEAD);
+      y_moving = stepper.axis_is_moving(Y_AXIS);
+    }
+    if (y_moving) {
+      if (y_neg_dir) { // -direction
         #if HAS_Y_MIN_STATE
           PROCESS_ENDSTOP_Y(MIN);
           #if   CORE_DIAG(XY, X, MIN)
@@ -861,9 +883,18 @@ void Endstops::update() {
     }
   #endif // HAS_Y_AXIS
 
+  bool z_moving, z_neg_dir;
   #if HAS_Z_AXIS
-    if (stepper.axis_is_moving(Z_AXIS)) {
-      if (!stepper.motor_direction(Z_AXIS_HEAD)) { // Z -direction. Gantry down, bed up.
+    if (ftMotion.cfg.mode) {
+      const bool z_moving_pos = ftMotion.axis_moving_pos(Z_AXIS_HEAD);
+      z_neg_dir = ftMotion.axis_moving_neg(Z_AXIS_HEAD);
+      z_moving = z_moving_pos || z_neg_dir;
+    } else {
+      z_neg_dir = !stepper.motor_direction(Z_AXIS_HEAD);
+      z_moving = stepper.axis_is_moving(Z_AXIS);
+    }
+    if (z_moving) {
+      if (z_neg_dir) { // -direction
         #if HAS_Z_MIN_STATE
           // If the Z_MIN_PIN is being used for the probe there's no
           // separate Z_MIN endstop. But a Z endstop could be wired
@@ -907,6 +938,7 @@ void Endstops::update() {
   #endif // HAS_Z_AXIS
 
   #if HAS_I_AXIS
+  // TODO: FT_Motion logic.
     if (stepper.axis_is_moving(I_AXIS)) {
       if (!stepper.motor_direction(I_AXIS_HEAD)) { // -direction
         #if HAS_I_MIN_STATE

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -26,24 +26,19 @@
 
 #include "ft_motion.h"
 #include "stepper.h" // Access stepper block queue function and abort status.
+#include "endstops.h"
 
 FTMotion ftMotion;
 
 #if !HAS_X_AXIS
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_ZV, "ftMotionMode_ZV requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_ZVD, "ftMotionMode_ZVD requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_ZVDD, "ftMotionMode_ZVD requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_ZVDDD, "ftMotionMode_ZVD requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_EI, "ftMotionMode_EI requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_2HEI, "ftMotionMode_2HEI requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_3HEI, "ftMotionMode_3HEI requires at least one linear axis.");
-  static_assert(FTM_DEFAULT_MODE == ftMotionMode_MZV, "ftMotionMode_MZV requires at least one linear axis.");
-#endif
-#if !HAS_DYNAMIC_FREQ_MM
-  static_assert(FTM_DEFAULT_DYNFREQ_MODE != dynFreqMode_Z_BASED, "dynFreqMode_Z_BASED requires a Z axis.");
-#endif
-#if !HAS_DYNAMIC_FREQ_G
-  static_assert(FTM_DEFAULT_DYNFREQ_MODE != dynFreqMode_MASS_BASED, "dynFreqMode_MASS_BASED requires an X axis and an extruder.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_ZV, "ftMotionCmpnstr_t_ZV requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_ZVD, "ftMotionCmpnstr_t_ZVD requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_ZVDD, "ftMotionCmpnstr_t_ZVD requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_ZVDDD, "ftMotionCmpnstr_t_ZVD requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_EI, "ftMotionCmpnstr_t_EI requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_2HEI, "ftMotionCmpnstr_t_2HEI requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_3HEI, "ftMotionCmpnstr_t_3HEI requires at least one linear axis.");
+  static_assert(FTM_DEFAULT_X_COMPENSATOR == ftMotionCmpnstr_t_MZV, "ftMotionCmpnstr_t_MZV requires at least one linear axis.");
 #endif
 
 //-----------------------------------------------------------------
@@ -53,30 +48,31 @@ FTMotion ftMotion;
 // Public variables.
 
 ft_config_t FTMotion::cfg;
+ftMotionTrajGenConfig_t FTMotion::traj_gen_cfg;
 bool FTMotion::busy; // = false
 ft_command_t FTMotion::stepperCmdBuff[FTM_STEPPERCMD_BUFF_SIZE] = {0U}; // Stepper commands buffer.
 int32_t FTMotion::stepperCmdBuff_produceIdx = 0, // Index of next stepper command write to the buffer.
         FTMotion::stepperCmdBuff_consumeIdx = 0; // Index of next stepper command read from the buffer.
 
 bool FTMotion::sts_stepperBusy = false;         // The stepper buffer has items and is in use.
+millis_t FTMotion::axis_pos_move_end_ti[NUM_AXIS_ENUMS] = {0},
+         FTMotion::axis_neg_move_end_ti[NUM_AXIS_ENUMS] = {0};
+
 
 // Private variables.
 
-// NOTE: These are sized for Ulendo FBS use.
 xyze_trajectory_t    FTMotion::traj;            // = {0.0f} Storage for fixed-time-based trajectory.
 xyze_trajectoryMod_t FTMotion::trajMod;         // = {0.0f} Storage for fixed time trajectory window.
 
-bool FTMotion::blockProcRdy = false,            // Indicates a block is ready to be processed.
-     FTMotion::blockProcRdy_z1 = false,         // Storage for the previous indicator.
-     FTMotion::blockProcDn = false;             // Indicates current block is done being processed.
-bool FTMotion::batchRdy = false;                // Indicates a batch of the fixed time trajectory
-                                                //  has been generated, is now available in the upper -
-                                                //  half of traj.x[], y, z ... e vectors, and is ready to be
-                                                //  post processed, if applicable, then interpolated.
-bool FTMotion::batchRdyForInterp = false;       // Indicates the batch is done being post processed,
-                                                //  if applicable, and is ready to be converted to step commands.
-bool FTMotion::runoutEna = false;               // True if runout of the block hasn't been done and is allowed.
-bool FTMotion::blockDataIsRunout = false;       // Indicates the last loaded block variables are for a runout.
+bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM, ...
+                                                // ... and reset when block is completely converted to FTM trajectory.
+bool FTMotion::batchRdy = false;                // Indicates a batch of the fixed time trajectory...
+                                                // ... has been generated, is now available in the upper -
+                                                // batch of traj.x[], y, z ... e vectors, and is ready to be
+                                                // post processed, if applicable, then interpolated. Reset when the
+                                                // data has been shifted out.
+bool FTMotion::batchRdyForInterp = false;       // Indicates the batch is done being post processed...
+                                                // ... if applicable, and is ready to be converted to step commands.
 
 // Trapezoid data variables.
 xyze_pos_t   FTMotion::startPosn,                     // (mm) Start position of block
@@ -97,22 +93,20 @@ uint32_t FTMotion::max_intervals;               // Total number of data points t
 
 // Make vector variables.
 uint32_t FTMotion::makeVector_idx = 0,          // Index of fixed time trajectory generation of the overall block.
-         FTMotion::makeVector_idx_z1 = 0,       // Storage for the previously calculated index above.
          FTMotion::makeVector_batchIdx = 0;     // Index of fixed time trajectory generation within the batch.
 
 // Interpolation variables.
 xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
 
-uint32_t FTMotion::interpIdx = 0,               // Index of current data point being interpolated.
-         FTMotion::interpIdx_z1 = 0;            // Storage for the previously calculated index above.
+uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
 // Shaping variables.
 #if HAS_X_AXIS
   FTMotion::shaping_t FTMotion::shaping = {
-    0, 0,
-    x:{ { 0.0f }, { 0.0f }, { 0 } },            // d_zi, Ai, Ni
+    0,
+    x:{ false, { 0.0f }, { 0.0f }, { 0 }, 0 },            // ena, d_zi, Ai, Ni, max_i
     #if HAS_Y_AXIS
-      y:{ { 0.0f }, { 0.0f }, { 0 } }           // d_zi, Ai, Ni
+      y:{ false, { 0.0f }, { 0.0f }, { 0 }, 0 }           // ena, d_zi, Ai, Ni, max_i
     #endif
   };
 #endif
@@ -123,7 +117,7 @@ uint32_t FTMotion::interpIdx = 0,               // Index of current data point b
   float FTMotion::e_advanced_z1 = 0.0f;   // (ms) Unit delay of advanced extruder position.
 #endif
 
-constexpr uint32_t last_batchIdx = (FTM_WINDOW_SIZE) - (FTM_BATCH_SIZE);
+constexpr uint32_t BATCH_SIDX_IN_WINDOW = (FTM_WINDOW_SIZE) - (FTM_BATCH_SIZE); // Batch start index in window.
 
 //-----------------------------------------------------------------
 // Function definitions.
@@ -131,35 +125,6 @@ constexpr uint32_t last_batchIdx = (FTM_WINDOW_SIZE) - (FTM_BATCH_SIZE);
 
 // Public functions.
 
-// Sets controller states to begin processing a block.
-void FTMotion::startBlockProc() {
-  blockProcRdy = true;
-  blockProcDn = false;
-  runoutEna = true;
-}
-
-// Move any free data points to the stepper buffer even if a full batch isn't ready.
-void FTMotion::runoutBlock() {
-
-  if (!runoutEna) return;
-
-  startPosn = endPosn_prevBlock;
-  ratio.reset();
-
-  max_intervals = cfg.modeHasShaper() ? shaper_intervals : 0;
-  if (max_intervals <= TERN(FTM_UNIFIED_BWS, FTM_BATCH_SIZE, min_max_intervals - (FTM_BATCH_SIZE)))
-    max_intervals = min_max_intervals;
-
-  max_intervals += (
-    #if ENABLED(FTM_UNIFIED_BWS)
-      FTM_WINDOW_SIZE - makeVector_batchIdx
-    #else
-      FTM_WINDOW_SIZE - ((last_batchIdx < (FTM_BATCH_SIZE)) ? 0 : makeVector_batchIdx)
-    #endif
-  );
-  blockProcRdy = blockDataIsRunout = true;
-  runoutEna = blockProcDn = false;
-}
 
 // Controller main, to be invoked from non-isr task.
 void FTMotion::loop() {
@@ -173,32 +138,48 @@ void FTMotion::loop() {
   // 4. Signal ready for new block.
   if (stepper.abort_current_block) {
     if (sts_stepperBusy) return;          // Wait until motion buffers are emptied
+    discard_planner_block_protected();
     reset();
-    blockProcDn = true;                   // Set queueing to look for next block.
+    blockProcRdy = false;                 // Set queueing to look for next block.
     stepper.abort_current_block = false;  // Abort finished.
   }
 
-  // Planner processing and block conversion.
-  if (!blockProcRdy) stepper.ftMotion_blockQueueUpdate();
 
-  if (blockProcRdy) {
-    if (!blockProcRdy_z1) { // One-shot.
-      if (!blockDataIsRunout) loadBlockData(stepper.current_block);
-      else blockDataIsRunout = false;
+  while(!blockProcRdy && (stepper.current_block = planner.get_current_block())){
+    if (stepper.current_block->is_sync()) { // Sync block? Sync the stepper counts and return.
+      TERN_(LASER_FEATURE, if (!(stepper.current_block->is_fan_sync() || stepper.current_block->is_pwr_sync()))) stepper._set_position(stepper.current_block->position);
+      discard_planner_block_protected();
+    } else {
+      loadBlockData(stepper.current_block); blockProcRdy = true;
     }
-    while (!blockProcDn && !batchRdy && (makeVector_idx - makeVector_idx_z1 < (FTM_POINTS_PER_LOOP)))
-      makeVector();
   }
 
-  // FBS / post processing.
+
+  if (blockProcRdy || traj_gen_cfg.mode) {
+    
+    if (!batchRdy) makeVector(); // Caution: Do not consolidate checks on blockProcRdy/batchRdy, as they are written by makeVector().
+    // When makeVector is finished: either blockProcRdy has been set false (because the block is
+    // done being processed) or batchRdy is set true, or both.
+
+    // Check if the block has been completely converted:
+    if (!blockProcRdy && !traj_gen_cfg.mode) {
+      discard_planner_block_protected();
+
+      // Check if the block needs to be runout:
+      if (!batchRdy && !planner.movesplanned()){
+        runoutBlock(); makeVector(); // Do an additional makeVector call to guarantee batchRdy set this loop.
+      }
+    }
+  }
+
+  
+  // Window/batch buffer management [and, optionally, FBS].
   if (batchRdy && !batchRdyForInterp) {
 
-    // Call Ulendo FBS here.
-
     #if ENABLED(FTM_UNIFIED_BWS)
-      trajMod = traj; // Move the window to traj
+      trajMod = traj; // Move the window to trajMod.
     #else
-      // Copy the uncompensated vectors.
+      // Copy the trajectories not modified by FBS.
       #define TCOPY(A) memcpy(trajMod.A, traj.A, sizeof(trajMod.A))
       LOGICAL_AXIS_CODE(
         TCOPY(e),
@@ -207,8 +188,8 @@ void FTMotion::loop() {
         TCOPY(u), TCOPY(v), TCOPY(w)
       );
 
-      // Shift the time series back in the window
-      #define TSHIFT(A) memcpy(traj.A, &traj.A[FTM_BATCH_SIZE], last_batchIdx * sizeof(traj.A[0]))
+      // Shift the time series back in the window.
+      #define TSHIFT(A) memcpy(traj.A, &traj.A[FTM_BATCH_SIZE], BATCH_SIDX_IN_WINDOW * sizeof(traj.A[0]))
       LOGICAL_AXIS_CODE(
         TSHIFT(e),
         TSHIFT(x), TSHIFT(y), TSHIFT(z),
@@ -217,17 +198,15 @@ void FTMotion::loop() {
       );
     #endif
 
-    // ... data is ready in trajMod.
-    batchRdyForInterp = true;
+    batchRdyForInterp = true; // Indicate data is ready in trajMod.
 
     batchRdy = false; // Clear so makeVector() can resume generating points.
   }
 
-  // Interpolation.
+
+  // Interpolation (generation of step commands from fixed time trajectory).
   while (batchRdyForInterp
-    && (stepperCmdBuffItems() < (FTM_STEPPERCMD_BUFF_SIZE) - (FTM_STEPS_PER_UNIT_TIME))
-    && (interpIdx - interpIdx_z1 < (FTM_STEPS_PER_LOOP))
-  ) {
+    && (stepperCmdBuffItems() < (FTM_STEPPERCMD_BUFF_SIZE) - (FTM_STEPS_PER_UNIT_TIME))) {
     convertToSteps(interpIdx);
     if (++interpIdx == FTM_BATCH_SIZE) {
       batchRdyForInterp = false;
@@ -236,196 +215,138 @@ void FTMotion::loop() {
   }
 
   // Report busy status to planner.
-  busy = (sts_stepperBusy || ((!blockProcDn && blockProcRdy) || batchRdy || batchRdyForInterp || runoutEna));
+  busy = (sts_stepperBusy || blockProcRdy || batchRdy || batchRdyForInterp || traj_gen_cfg.mode);
 
-  blockProcRdy_z1 = blockProcRdy;
-  makeVector_idx_z1 = makeVector_idx;
-  interpIdx_z1 = interpIdx;
 }
 
 #if HAS_X_AXIS
 
   // Refresh the gains used by shaping functions.
-  // To be called on init or mode or zeta change.
+  void FTMotion::AxisShaping::set_axis_shaping_A(const ftMotionCmpnstr_t shaper, const_float_t zeta, const_float_t vtol) {
 
-  void FTMotion::Shaping::updateShapingA(float zeta[]/*=cfg.zeta*/, float vtol[]/*=cfg.vtol*/) {
+    const float K = exp(-zeta * M_PI / sqrt(1.f - sq(zeta))),
+                K2 = sq(K);
 
-    const float Kx = exp(-zeta[0] * M_PI / sqrt(1.0f - sq(zeta[0]))),
-                Ky = exp(-zeta[1] * M_PI / sqrt(1.0f - sq(zeta[1]))),
-                Kx2 = sq(Kx),
-                Ky2 = sq(Ky);
+    switch (shaper) {
 
-    switch (cfg.mode) {
-
-      case ftMotionMode_ZV:
+      case ftMotionCmpnstr_ZV:
         max_i = 1U;
-        x.Ai[0] = 1.0f / (1.0f + Kx);
-        x.Ai[1] = x.Ai[0] * Kx;
-
-        y.Ai[0] = 1.0f / (1.0f + Ky);
-        y.Ai[1] = y.Ai[0] * Ky;
+        Ai[0] = 1.0f / (1.0f + K);
+        Ai[1] = Ai[0] * K;
         break;
 
-      case ftMotionMode_ZVD:
+      case ftMotionCmpnstr_ZVD:
         max_i = 2U;
-        x.Ai[0] = 1.0f / (1.0f + 2.0f * Kx + Kx2);
-        x.Ai[1] = x.Ai[0] * 2.0f * Kx;
-        x.Ai[2] = x.Ai[0] * Kx2;
-
-        y.Ai[0] = 1.0f / (1.0f + 2.0f * Ky + Ky2);
-        y.Ai[1] = y.Ai[0] * 2.0f * Ky;
-        y.Ai[2] = y.Ai[0] * Ky2;
+        Ai[0] = 1.0f / (1.0f + 2.0f * K + K2);
+        Ai[1] = Ai[0] * 2.0f * K;
+        Ai[2] = Ai[0] * K2;
         break;
 
-      case ftMotionMode_ZVDD:
+      case ftMotionCmpnstr_ZVDD:
         max_i = 3U;
-        x.Ai[0] = 1.0f / (1.0f + 3.0f * Kx + 3.0f * Kx2 + cu(Kx));
-        x.Ai[1] = x.Ai[0] * 3.0f * Kx;
-        x.Ai[2] = x.Ai[0] * 3.0f * Kx2;
-        x.Ai[3] = x.Ai[0] * cu(Kx);
-
-        y.Ai[0] = 1.0f / (1.0f + 3.0f * Ky + 3.0f * Ky2 + cu(Ky));
-        y.Ai[1] = y.Ai[0] * 3.0f * Ky;
-        y.Ai[2] = y.Ai[0] * 3.0f * Ky2;
-        y.Ai[3] = y.Ai[0] * cu(Ky);
+        Ai[0] = 1.0f / (1.0f + 3.0f * K + 3.0f * K2 + cu(K));
+        Ai[1] = Ai[0] * 3.0f * K;
+        Ai[2] = Ai[0] * 3.0f * K2;
+        Ai[3] = Ai[0] * cu(K);
         break;
 
-      case ftMotionMode_ZVDDD:
+      case ftMotionCmpnstr_ZVDDD:
         max_i = 4U;
-        x.Ai[0] = 1.0f / (1.0f + 4.0f * Kx + 6.0f * Kx2 + 4.0f * cu(Kx) + sq(Kx2));
-        x.Ai[1] = x.Ai[0] * 4.0f * Kx;
-        x.Ai[2] = x.Ai[0] * 6.0f * Kx2;
-        x.Ai[3] = x.Ai[0] * 4.0f * cu(Kx);
-        x.Ai[4] = x.Ai[0] * sq(Kx2);
-
-        y.Ai[0] = 1.0f / (1.0f + 4.0f * Ky + 6.0f * Ky2 + 4.0f * cu(Ky) + sq(Ky2));
-        y.Ai[1] = y.Ai[0] * 4.0f * Ky;
-        y.Ai[2] = y.Ai[0] * 6.0f * Ky2;
-        y.Ai[3] = y.Ai[0] * 4.0f * cu(Ky);
-        y.Ai[4] = y.Ai[0] * sq(Ky2);
+        Ai[0] = 1.0f / (1.0f + 4.0f * K + 6.0f * K2 + 4.0f * cu(K) + sq(K2));
+        Ai[1] = Ai[0] * 4.0f * K;
+        Ai[2] = Ai[0] * 6.0f * K2;
+        Ai[3] = Ai[0] * 4.0f * cu(K);
+        Ai[4] = Ai[0] * sq(K2);
         break;
 
-      case ftMotionMode_EI: {
+      case ftMotionCmpnstr_EI: {
         max_i = 2U;
-        x.Ai[0] = 0.25f * (1.0f + vtol[0]);
-        x.Ai[1] = 0.50f * (1.0f - vtol[0]) * Kx;
-        x.Ai[2] = x.Ai[0] * Kx2;
+        Ai[0] = 0.25f * (1.0f + vtol);
+        Ai[1] = 0.50f * (1.0f - vtol) * K;
+        Ai[2] = Ai[0] * K2;
 
-        y.Ai[0] = 0.25f * (1.0f + vtol[1]);
-        y.Ai[1] = 0.50f * (1.0f - vtol[1]) * Ky;
-        y.Ai[2] = y.Ai[0] * Ky2;
-
-        const float X_adj = 1.0f / (x.Ai[0] + x.Ai[1] + x.Ai[2]);
-        const float Y_adj = 1.0f / (y.Ai[0] + y.Ai[1] + y.Ai[2]);
+        const float adj = 1.0f / (Ai[0] + Ai[1] + Ai[2]);
         for (uint32_t i = 0U; i < 3U; i++) {
-          x.Ai[i] *= X_adj;
-          y.Ai[i] *= Y_adj;
+          Ai[i] *= adj;
         }
       }
       break;
 
-      case ftMotionMode_2HEI: {
+      case ftMotionCmpnstr_2HEI: {
         max_i = 3U;
-        const float vtolx2 = sq(vtol[0]);
+        const float vtolx2 = sq(vtol);
         const float X = pow(vtolx2 * (sqrt(1.0f - vtolx2) + 1.0f), 1.0f / 3.0f);
-        x.Ai[0] = (3.0f * sq(X) + 2.0f * X + 3.0f * vtolx2) / (16.0f * X);
-        x.Ai[1] = (0.5f - x.Ai[0]) * Kx;
-        x.Ai[2] = x.Ai[1] * Kx;
-        x.Ai[3] = x.Ai[0] * cu(Kx);
+        Ai[0] = (3.0f * sq(X) + 2.0f * X + 3.0f * vtolx2) / (16.0f * X);
+        Ai[1] = (0.5f - Ai[0]) * K;
+        Ai[2] = Ai[1] * K;
+        Ai[3] = Ai[0] * cu(K);
 
-        const float vtoly2 = sq(vtol[1]);
-        const float Y = pow(vtoly2 * (sqrt(1.0f - vtoly2) + 1.0f), 1.0f / 3.0f);
-        y.Ai[0] = (3.0f * sq(Y) + 2.0f * Y + 3.0f * vtoly2) / (16.0f * Y);
-        y.Ai[1] = (0.5f - y.Ai[0]) * Ky;
-        y.Ai[2] = y.Ai[1] * Ky;
-        y.Ai[3] = y.Ai[0] * cu(Ky);
-
-        const float X_adj = 1.0f / (x.Ai[0] + x.Ai[1] + x.Ai[2] + x.Ai[3]);
-        const float Y_adj = 1.0f / (y.Ai[0] + y.Ai[1] + y.Ai[2] + y.Ai[3]);
+        const float adj = 1.0f / (Ai[0] + Ai[1] + Ai[2] + Ai[3]);
         for (uint32_t i = 0U; i < 4U; i++) {
-          x.Ai[i] *= X_adj;
-          y.Ai[i] *= Y_adj;
+          Ai[i] *= adj;
         }
       }
       break;
 
-      case ftMotionMode_3HEI: {
+      case ftMotionCmpnstr_3HEI: {
         max_i = 4U;
-        x.Ai[0] = 0.0625f * ( 1.0f + 3.0f * vtol[0] + 2.0f * sqrt( 2.0f * ( vtol[0] + 1.0f ) * vtol[0] ) );
-        x.Ai[1] = 0.25f * ( 1.0f - vtol[0] ) * Kx;
-        x.Ai[2] = ( 0.5f * ( 1.0f + vtol[0] ) - 2.0f * x.Ai[0] ) * Kx2;
-        x.Ai[3] = x.Ai[1] * Kx2;
-        x.Ai[4] = x.Ai[0] * sq(Kx2);
+        Ai[0] = 0.0625f * ( 1.0f + 3.0f * vtol + 2.0f * sqrt( 2.0f * ( vtol + 1.0f ) * vtol ) );
+        Ai[1] = 0.25f * ( 1.0f - vtol ) * K;
+        Ai[2] = ( 0.5f * ( 1.0f + vtol ) - 2.0f * Ai[0] ) * K2;
+        Ai[3] = Ai[1] * K2;
+        Ai[4] = Ai[0] * sq(K2);
 
-        y.Ai[0] = 0.0625f * (1.0f + 3.0f * vtol[1] + 2.0f * sqrt(2.0f * (vtol[1] + 1.0f) * vtol[1]));
-        y.Ai[1] = 0.25f * (1.0f - vtol[1]) * Ky;
-        y.Ai[2] = (0.5f * (1.0f + vtol[1]) - 2.0f * y.Ai[0]) * Ky2;
-        y.Ai[3] = y.Ai[1] * Ky2;
-        y.Ai[4] = y.Ai[0] * sq(Ky2);
-
-        const float X_adj = 1.0f / (x.Ai[0] + x.Ai[1] + x.Ai[2] + x.Ai[3] + x.Ai[4]);
-        const float Y_adj = 1.0f / (y.Ai[0] + y.Ai[1] + y.Ai[2] + y.Ai[3] + y.Ai[4]);
+        const float adj = 1.0f / (Ai[0] + Ai[1] + Ai[2] + Ai[3] + Ai[4]);
         for (uint32_t i = 0U; i < 5U; i++) {
-          x.Ai[i] *= X_adj;
-          y.Ai[i] *= Y_adj;
+          Ai[i] *= adj;
         }
       }
       break;
 
-      case ftMotionMode_MZV: {
+      case ftMotionCmpnstr_MZV: {
         max_i = 2U;
-        const float Bx = 1.4142135623730950488016887242097f * Kx;
-        x.Ai[0] = 1.0f / (1.0f + Bx + Kx2);
-        x.Ai[1] = x.Ai[0] * Bx;
-        x.Ai[2] = x.Ai[0] * Kx2;
-
-        const float By = 1.4142135623730950488016887242097f * Ky;
-        y.Ai[0] = 1.0f / (1.0f + By + Ky2);
-        y.Ai[1] = y.Ai[0] * By;
-        y.Ai[2] = y.Ai[0] * Ky2;
+        const float Bx = 1.4142135623730950488016887242097f * K;
+        Ai[0] = 1.0f / (1.0f + Bx + K2);
+        Ai[1] = Ai[0] * Bx;
+        Ai[2] = Ai[0] * K2;
       }
       break;
 
       default:
-        ZERO(x.Ai);
-        ZERO(y.Ai);
+        ZERO(Ai);
         max_i = 0;
     }
 
   }
-
-  void FTMotion::updateShapingA(float zeta[]/*=cfg.zeta*/, float vtol[]/*=cfg.vtol*/) {
-    shaping.updateShapingA(zeta, vtol);
-  }
+  
 
   // Refresh the indices used by shaping functions.
-  // To be called when frequencies change.
-
-  void FTMotion::AxisShaping::updateShapingN(const_float_t f, const_float_t df) {
-    // Protections omitted for DBZ and for index exceeding array length.
-    switch (cfg.mode) {
-      case ftMotionMode_ZV:
+  void FTMotion::AxisShaping::set_axis_shaping_N(const ftMotionCmpnstr_t shaper, const_float_t f, const_float_t zeta) {
+    // Note that protections are omitted for DBZ and for index exceeding array length.
+    const float df = sqrt ( 1.f - sq(zeta) );
+    switch (shaper) {
+      case ftMotionCmpnstr_ZV:
         Ni[1] = round((0.5f / f / df) * (FTM_FS));
         break;
-      case ftMotionMode_ZVD:
-      case ftMotionMode_EI:
+      case ftMotionCmpnstr_ZVD:
+      case ftMotionCmpnstr_EI:
         Ni[1] = round((0.5f / f / df) * (FTM_FS));
         Ni[2] = Ni[1] + Ni[1];
         break;
-      case ftMotionMode_ZVDD:
-      case ftMotionMode_2HEI:
+      case ftMotionCmpnstr_ZVDD:
+      case ftMotionCmpnstr_2HEI:
         Ni[1] = round((0.5f / f / df) * (FTM_FS));
         Ni[2] = Ni[1] + Ni[1];
         Ni[3] = Ni[2] + Ni[1];
         break;
-      case ftMotionMode_ZVDDD:
-      case ftMotionMode_3HEI:
+      case ftMotionCmpnstr_ZVDDD:
+      case ftMotionCmpnstr_3HEI:
         Ni[1] = round((0.5f / f / df) * (FTM_FS));
         Ni[2] = Ni[1] + Ni[1];
         Ni[3] = Ni[2] + Ni[1];
         Ni[4] = Ni[3] + Ni[1];
         break;
-      case ftMotionMode_MZV:
+      case ftMotionCmpnstr_MZV:
         Ni[1] = round((0.375f / f / df) * (FTM_FS));
         Ni[2] = Ni[1] + Ni[1];
         break;
@@ -433,13 +354,14 @@ void FTMotion::loop() {
     }
   }
 
-  void FTMotion::updateShapingN(const_float_t xf OPTARG(HAS_Y_AXIS, const_float_t yf), float zeta[]/*=cfg.zeta*/) {
-    const float xdf = sqrt(1.0f - sq(zeta[0]));
-    shaping.x.updateShapingN(xf, xdf);
-
+  void FTMotion::update_shaping_params() {
+    shaping.x.set_axis_shaping_A(cfg.cmpnstr[X_AXIS], cfg.zeta[X_AXIS], cfg.vtol[X_AXIS]);
+    shaping.x.set_axis_shaping_N(cfg.cmpnstr[X_AXIS], cfg.baseFreq[X_AXIS], cfg.zeta[X_AXIS]);
+    shaping.x.ena = WITHIN(cfg.cmpnstr[X_AXIS], ftMotionCmpnstr_ZV, ftMotionCmpnstr_MZV);
     #if HAS_Y_AXIS
-      const float ydf = sqrt(1.0f - sq(zeta[1]));
-      shaping.y.updateShapingN(yf, ydf);
+      shaping.y.set_axis_shaping_N(cfg.cmpnstr[Y_AXIS], cfg.baseFreq[Y_AXIS], cfg.zeta[Y_AXIS]);
+      shaping.y.set_axis_shaping_A(cfg.cmpnstr[Y_AXIS], cfg.zeta[Y_AXIS], cfg.vtol[Y_AXIS]);
+      shaping.y.ena =  WITHIN(cfg.cmpnstr[Y_AXIS], ftMotionCmpnstr_ZV, ftMotionCmpnstr_MZV);
     #endif
   }
 
@@ -452,17 +374,15 @@ void FTMotion::reset() {
 
   traj.reset();
 
-  blockProcRdy = blockProcRdy_z1 = blockProcDn = false;
-  batchRdy = batchRdyForInterp = false;
-  runoutEna = false;
+  blockProcRdy = batchRdy = batchRdyForInterp = false;
 
   endPosn_prevBlock.reset();
 
-  makeVector_idx = makeVector_idx_z1 = 0;
-  makeVector_batchIdx = TERN(FTM_UNIFIED_BWS, 0, _MAX(last_batchIdx, FTM_BATCH_SIZE));
+  makeVector_idx = 0;
+  makeVector_batchIdx = BATCH_SIDX_IN_WINDOW;
 
   steps.reset();
-  interpIdx = interpIdx_z1 = 0;
+  interpIdx = 0;
 
   #if HAS_X_AXIS
     ZERO(shaping.x.d_zi);
@@ -471,9 +391,96 @@ void FTMotion::reset() {
   #endif
 
   TERN_(HAS_EXTRUDERS, e_raw_z1 = e_advanced_z1 = 0.0f);
+
+  NUM_AXIS_CODE(
+    axis_pos_move_end_ti[A_AXIS] = 0,
+    axis_pos_move_end_ti[B_AXIS] = 0,
+    axis_pos_move_end_ti[C_AXIS] = 0,
+    axis_pos_move_end_ti[I_AXIS] = 0,
+    axis_pos_move_end_ti[J_AXIS] = 0,
+    axis_pos_move_end_ti[K_AXIS] = 0,
+    axis_pos_move_end_ti[U_AXIS] = 0,
+    axis_pos_move_end_ti[V_AXIS] = 0,
+    axis_pos_move_end_ti[W_AXIS] = 0
+  );
+  #if ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX)
+    axis_pos_move_end_ti[X_HEAD] = 0;
+    axis_pos_move_end_ti[Y_HEAD] = 0;
+  #endif
+
+  NUM_AXIS_CODE(
+    axis_neg_move_end_ti[A_AXIS] = 0,
+    axis_neg_move_end_ti[B_AXIS] = 0,
+    axis_neg_move_end_ti[C_AXIS] = 0,
+    axis_neg_move_end_ti[I_AXIS] = 0,
+    axis_neg_move_end_ti[J_AXIS] = 0,
+    axis_neg_move_end_ti[K_AXIS] = 0,
+    axis_neg_move_end_ti[U_AXIS] = 0,
+    axis_neg_move_end_ti[V_AXIS] = 0,
+    axis_neg_move_end_ti[W_AXIS] = 0
+  );
+  #if ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX)
+    axis_neg_move_end_ti[X_HEAD] = 0;
+    axis_neg_move_end_ti[Y_HEAD] = 0;
+  #endif
+
 }
 
+
+void FTMotion::setup_traj_gen(uint32_t intervals) {
+  // Extend the intervals by propagation time and some margin to 
+  // ensure motion is complete when completion message is sent.
+  max_intervals = FTM_BATCH_SIZE*(PROP_BATCHES+ceil(((float)(intervals)+FTM_FS*(0.5f+(float)(FTM_STEPPERCMD_BUFF_SIZE)/float(FTM_STEPPER_FS)))/FTM_BATCH_SIZE));
+  reset();
+  busy = true;
+}
+
+
 // Private functions.
+
+
+void FTMotion::discard_planner_block_protected() {
+  if (stepper.current_block) {  // Safeguard in case current_block must not be null (it will
+                                // be null when the "block" is a runout or generated) in order
+                                // to use planner.release_current_block(). 
+    stepper.current_block = nullptr;
+    planner.release_current_block();  // FTM uses release_current_block() instead of discard_current_block(),
+                                      // as in block_phase_isr(). This change is to avoid invoking axis_did_move.reset().
+                                      // current_block = nullptr is added to replicate discard without axis_did_move reset.
+                                      // Note invoking axis_did_move.reset() causes no issue since FTM's stepper refreshes
+                                      // its values every ISR.
+  }
+}
+
+// Sets up a pseudo block to allow motion to settle buffers to empty. This is
+// called when the planner has only one block left. The buffers will be filled
+// with the last commanded position by setting the startPosn block variable to
+// the last position of the previous block and all ratios to zero such that no
+// axes' positions are incremented.
+void FTMotion::runoutBlock() {
+
+  startPosn = endPosn_prevBlock;
+  ratio.reset();
+
+  int32_t n_to_fill_batch = FTM_WINDOW_SIZE - makeVector_batchIdx;
+  
+  // This line or function is to be modified for FBS use; do not optimize out.
+  int32_t n_to_settle_cmpnstr = num_samples_cmpnstr_settle();
+
+  int32_t n_to_fill_batch_after_settling = (n_to_settle_cmpnstr > n_to_fill_batch) ?
+    FTM_BATCH_SIZE - ((n_to_settle_cmpnstr - n_to_fill_batch) % FTM_BATCH_SIZE) : n_to_fill_batch - n_to_settle_cmpnstr;
+
+  int32_t n_to_settle_and_fill_batch = n_to_settle_cmpnstr + n_to_fill_batch_after_settling;
+
+  int32_t N_needed_to_propagate_to_stepper = PROP_BATCHES;
+
+  int32_t n_to_use = N_needed_to_propagate_to_stepper*FTM_BATCH_SIZE + n_to_settle_and_fill_batch;
+
+  max_intervals = n_to_use;
+
+  blockProcRdy = true;
+}
+
 
 // Auxiliary function to get number of step commands in the buffer.
 int32_t FTMotion::stepperCmdBuffItems() {
@@ -483,10 +490,7 @@ int32_t FTMotion::stepperCmdBuffItems() {
 
 // Initializes storage variables before startup.
 void FTMotion::init() {
-  #if HAS_X_AXIS
-    refreshShapingN();
-    updateShapingA();
-  #endif
+  update_shaping_params();
   reset(); // Precautionary.
 }
 
@@ -591,113 +595,167 @@ void FTMotion::loadBlockData(block_t * const current_block) {
   max_intervals = N1 + N2 + N3;
 
   endPosn_prevBlock += moveDist;
+
+  millis_t move_end_ti = millis() + SEC_TO_MS(FTM_TS*(float)(max_intervals + num_samples_cmpnstr_settle() + (PROP_BATCHES+1)*FTM_BATCH_SIZE) + ((float)FTM_STEPPERCMD_BUFF_SIZE/(float)FTM_STEPPER_FS));
+  
+  #if CORE_IS_XY
+    if (moveDist.x > 0.f)              axis_pos_move_end_ti[A_AXIS] = move_end_ti;
+    if (moveDist.y > 0.f)              axis_pos_move_end_ti[B_AXIS] = move_end_ti;
+    if (moveDist.x + moveDist.y > 0.f) axis_pos_move_end_ti[X_HEAD] = move_end_ti;
+    if (moveDist.x - moveDist.y > 0.f) axis_pos_move_end_ti[Y_HEAD] = move_end_ti;
+    if (moveDist.x < 0.f)              axis_neg_move_end_ti[A_AXIS] = move_end_ti;
+    if (moveDist.y < 0.f)              axis_neg_move_end_ti[B_AXIS] = move_end_ti;
+    if (moveDist.x + moveDist.y < 0.f) axis_neg_move_end_ti[X_HEAD] = move_end_ti;
+    if (moveDist.x - moveDist.y < 0.f) axis_neg_move_end_ti[Y_HEAD] = move_end_ti;
+  #else
+    if (moveDist.x > 0.f)              axis_pos_move_end_ti[X_AXIS] = move_end_ti;
+    if (moveDist.y > 0.f)              axis_pos_move_end_ti[Y_AXIS] = move_end_ti;
+    if (moveDist.x < 0.f)              axis_neg_move_end_ti[X_AXIS] = move_end_ti;
+    if (moveDist.y < 0.f)              axis_neg_move_end_ti[Y_AXIS] = move_end_ti;
+  #endif
+  if (moveDist.z > 0.f) axis_pos_move_end_ti[Z_AXIS] = move_end_ti;
+  if (moveDist.z < 0.f) axis_neg_move_end_ti[Z_AXIS] = move_end_ti;
+  // if (moveDist.i > 0.f) axis_pos_move_end_ti[I_AXIS] = move_end_ti;
+  // if (moveDist.i < 0.f) axis_neg_move_end_ti[I_AXIS] = move_end_ti;
+  // if (moveDist.j > 0.f) axis_pos_move_end_ti[J_AXIS] = move_end_ti;
+  // if (moveDist.j < 0.f) axis_neg_move_end_ti[J_AXIS] = move_end_ti;
+  // if (moveDist.k > 0.f) axis_pos_move_end_ti[K_AXIS] = move_end_ti;
+  // if (moveDist.k < 0.f) axis_neg_move_end_ti[K_AXIS] = move_end_ti;
+  // if (moveDist.u > 0.f) axis_pos_move_end_ti[U_AXIS] = move_end_ti;
+  // if (moveDist.u < 0.f) axis_neg_move_end_ti[U_AXIS] = move_end_ti;
+  // .
+  // .
+  // .
+
+  // If the endstop is already pressed, endstop interrupts won't invoke
+  // endstop_triggered and the move will grind. So check here for a
+  // triggered endstop, which shortly marks the block for discard.
+  endstops.update();
+
 }
 
 // Generate data points of the trajectory.
 void FTMotion::makeVector() {
-  float accel_k = 0.0f;                                 // (mm/s^2) Acceleration K factor
-  float tau = (makeVector_idx + 1) * (FTM_TS);          // (s) Time since start of block
-  float dist = 0.0f;                                    // (mm) Distance traveled
+  do {
+    if (traj_gen_cfg.mode == trajGenMode_SWEEPC_X || traj_gen_cfg.mode == trajGenMode_SWEEPC_Y) {
+      float s_ = 0.0f;
 
-  if (makeVector_idx < N1) {
-    // Acceleration phase
-    dist = (f_s * tau) + (0.5f * accel_P * sq(tau));    // (mm) Distance traveled for acceleration phase since start of block
-    accel_k = accel_P;                                  // (mm/s^2) Acceleration K factor from Accel phase
-  }
-  else if (makeVector_idx < (N1 + N2)) {
-    // Coasting phase
-    dist = s_1e + F_P * (tau - N1 * (FTM_TS));          // (mm) Distance traveled for coasting phase since start of block
-    //accel_k = 0.0f;
-  }
-  else {
-    // Deceleration phase
-    tau -= (N1 + N2) * (FTM_TS);                        // (s) Time since start of decel phase
-    dist = s_2e + F_P * tau + 0.5f * decel_P * sq(tau); // (mm) Distance traveled for deceleration phase since start of block
-    accel_k = decel_P;                                  // (mm/s^2) Acceleration K factor from Decel phase
-  }
+      const float tau = makeVector_idx * FTM_TS;
 
-  LOGICAL_AXIS_CODE(
-    traj.e[makeVector_batchIdx] = startPosn.e + ratio.e * dist,
-    traj.x[makeVector_batchIdx] = startPosn.x + ratio.x * dist,
-    traj.y[makeVector_batchIdx] = startPosn.y + ratio.y * dist,
-    traj.z[makeVector_batchIdx] = startPosn.z + ratio.z * dist,
-    traj.i[makeVector_batchIdx] = startPosn.i + ratio.i * dist,
-    traj.j[makeVector_batchIdx] = startPosn.j + ratio.j * dist,
-    traj.k[makeVector_batchIdx] = startPosn.k + ratio.k * dist,
-    traj.u[makeVector_batchIdx] = startPosn.u + ratio.u * dist,
-    traj.v[makeVector_batchIdx] = startPosn.v + ratio.v * dist,
-    traj.w[makeVector_batchIdx] = startPosn.w + ratio.w * dist
-  );
-
-  #if HAS_EXTRUDERS
-    if (cfg.linearAdvEna) {
-      float dedt_adj = (traj.e[makeVector_batchIdx] - e_raw_z1) * (FTM_FS);
-      if (ratio.e > 0.0f) dedt_adj += accel_k * cfg.linearAdvK;
-
-      e_raw_z1 = traj.e[makeVector_batchIdx];
-      e_advanced_z1 += dedt_adj * (FTM_TS);
-      traj.e[makeVector_batchIdx] = e_advanced_z1;
-    }
-  #endif
-
-  // Update shaping parameters if needed.
-
-  switch (cfg.dynFreqMode) {
-
-    #if HAS_DYNAMIC_FREQ_MM
-      case dynFreqMode_Z_BASED:
-        if (traj.z[makeVector_batchIdx] != 0.0f) { // Only update if Z changed.
-                 const float xf = cfg.baseFreq[X_AXIS] + cfg.dynFreqK[X_AXIS] * traj.z[makeVector_batchIdx]
-          OPTARG(HAS_Y_AXIS, yf = cfg.baseFreq[Y_AXIS] + cfg.dynFreqK[Y_AXIS] * traj.z[makeVector_batchIdx]);
-          updateShapingN(_MAX(xf, FTM_MIN_SHAPE_FREQ) OPTARG(HAS_Y_AXIS, _MAX(yf, FTM_MIN_SHAPE_FREQ)));
-        }
-        break;
-    #endif
-
-    #if HAS_DYNAMIC_FREQ_G
-      case dynFreqMode_MASS_BASED:
-        // Update constantly. The optimization done for Z value makes
-        // less sense for E, as E is expected to constantly change.
-        updateShapingN(      cfg.baseFreq[X_AXIS] + cfg.dynFreqK[X_AXIS] * traj.e[makeVector_batchIdx]
-          OPTARG(HAS_Y_AXIS, cfg.baseFreq[Y_AXIS] + cfg.dynFreqK[Y_AXIS] * traj.e[makeVector_batchIdx]) );
-        break;
-    #endif
-
-    default: break;
-  }
-
-  // Apply shaping if in mode.
-  #if HAS_X_AXIS
-    if (cfg.modeHasShaper()) {
-      shaping.x.d_zi[shaping.zi_idx] = traj.x[makeVector_batchIdx];
-      traj.x[makeVector_batchIdx] *= shaping.x.Ai[0];
-      #if HAS_Y_AXIS
-        shaping.y.d_zi[shaping.zi_idx] = traj.y[makeVector_batchIdx];
-        traj.y[makeVector_batchIdx] *= shaping.y.Ai[0];
-      #endif
-      for (uint32_t i = 1U; i <= shaping.max_i; i++) {
-        const uint32_t udiffx = shaping.zi_idx - shaping.x.Ni[i];
-        traj.x[makeVector_batchIdx] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
-        #if HAS_Y_AXIS
-          const uint32_t udiffy = shaping.zi_idx - shaping.y.Ni[i];
-          traj.y[makeVector_batchIdx] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
-        #endif
+      if ( tau <= traj_gen_cfg.pcws_ti[0] ){ s_ = 0.f; }
+      
+      else if ( tau <= traj_gen_cfg.pcws_ti[1] ){
+        const float tau_ = tau - traj_gen_cfg.pcws_ti[0];
+        if (tau_ < traj_gen_cfg.step_ti){ s_ = traj_gen_cfg.step_a_x_0p5 * sq(tau_); }
+        else if (tau_ < traj_gen_cfg.step_ti_x_3){ const float k_ = tau_ - traj_gen_cfg.step_ti_x_2; s_ = traj_gen_cfg.step_a_x_step_ti_x_step_ti - traj_gen_cfg.step_a_x_0p5 * sq(k_); }
+        else { const float k_ = tau_ - traj_gen_cfg.step_ti_x_4; s_ = traj_gen_cfg.step_a_x_0p5 * sq(k_); }
       }
-      if (++shaping.zi_idx == (FTM_ZMAX)) shaping.zi_idx = 0;
+      else if ( tau <= traj_gen_cfg.pcws_ti[2] ){ s_ = 0.0f; }
+      
+      else if ( tau <= traj_gen_cfg.pcws_ti[3] ){
+        const float tau_ = tau - traj_gen_cfg.pcws_ti[2];
+        const float tau_tau_ = sq(tau_);
+        const float tau_tau_tau_ = tau_ * tau_tau_;
+        const float k_ = 1.f / (2.f*traj_gen_cfg.k1*tau_ + traj_gen_cfg.k2);
+        const float A_ = ((tau_tau_tau_ < 1.f) ? tau_tau_tau_ : 1.f) * traj_gen_cfg.a * sq(k_);
+        s_ = A_ * sin( traj_gen_cfg.k1*tau_tau_ + traj_gen_cfg.k2*tau_ );
+      }
+      else if ( tau <= traj_gen_cfg.pcws_ti[4] ){ s_ = 0.f; }
+
+      else if ( tau <= traj_gen_cfg.pcws_ti[5] ){
+        const float tau_ = tau - traj_gen_cfg.pcws_ti[4];
+        if (tau_ < traj_gen_cfg.step_ti){ s_ = -traj_gen_cfg.step_a_x_0p5 * sq(tau_); }
+        else if (tau_ < traj_gen_cfg.step_ti_x_3){ const float k_ = tau_ - traj_gen_cfg.step_ti_x_2; s_ = -traj_gen_cfg.step_a_x_step_ti_x_step_ti + traj_gen_cfg.step_a_x_0p5 * sq(k_); }
+        else { const float k_ = tau_ - traj_gen_cfg.step_ti_x_4; s_ = -traj_gen_cfg.step_a_x_0p5 * sq(k_); }
+      }
+      else { s_ = 0.f; }
+
+      if (traj_gen_cfg.mode == trajGenMode_SWEEPC_X ) traj.x[makeVector_batchIdx] = s_;
+      else traj.y[makeVector_batchIdx] = s_;
+
+    } else { // Planner mode.
+      float accel_k = 0.0f;                                 // (mm/s^2) Acceleration K factor
+      float tau = (makeVector_idx + 1) * (FTM_TS);    // (s) Time since start of block
+      float dist = 0.0f;                                    // (mm) Distance traveled
+
+      if (makeVector_idx < N1) {
+        // Acceleration phase
+        dist = (f_s * tau) + (0.5f * accel_P * sq(tau));    // (mm) Distance traveled for acceleration phase since start of block
+        accel_k = accel_P;                                  // (mm/s^2) Acceleration K factor from Accel phase
+      }
+      else if (makeVector_idx < (N1 + N2)) {
+        // Coasting phase
+        dist = s_1e + F_P * (tau - N1 * (FTM_TS));          // (mm) Distance traveled for coasting phase since start of block
+        //accel_k = 0.0f;
+      }
+      else {
+        // Deceleration phase
+        tau -= (N1 + N2) * (FTM_TS);                        // (s) Time since start of decel phase
+        dist = s_2e + F_P * tau + 0.5f * decel_P * sq(tau); // (mm) Distance traveled for deceleration phase since start of block
+        accel_k = decel_P;                                  // (mm/s^2) Acceleration K factor from Decel phase
+      }
+
+      LOGICAL_AXIS_CODE(
+        traj.e[makeVector_batchIdx] = startPosn.e + ratio.e * dist,
+        traj.x[makeVector_batchIdx] = startPosn.x + ratio.x * dist,
+        traj.y[makeVector_batchIdx] = startPosn.y + ratio.y * dist,
+        traj.z[makeVector_batchIdx] = startPosn.z + ratio.z * dist,
+        traj.i[makeVector_batchIdx] = startPosn.i + ratio.i * dist,
+        traj.j[makeVector_batchIdx] = startPosn.j + ratio.j * dist,
+        traj.k[makeVector_batchIdx] = startPosn.k + ratio.k * dist,
+        traj.u[makeVector_batchIdx] = startPosn.u + ratio.u * dist,
+        traj.v[makeVector_batchIdx] = startPosn.v + ratio.v * dist,
+        traj.w[makeVector_batchIdx] = startPosn.w + ratio.w * dist
+      );
+
+      #if HAS_EXTRUDERS
+        if (cfg.linearAdvEna) {
+          float dedt_adj = (traj.e[makeVector_batchIdx] - e_raw_z1) * (FTM_FS);
+          if (ratio.e > 0.0f) dedt_adj += accel_k * cfg.linearAdvK;
+
+          e_raw_z1 = traj.e[makeVector_batchIdx];
+          e_advanced_z1 += dedt_adj * (FTM_TS);
+          traj.e[makeVector_batchIdx] = e_advanced_z1;
+        }
+      #endif
     }
-  #endif
 
-  // Filled up the queue with regular and shaped steps
-  if (++makeVector_batchIdx == FTM_WINDOW_SIZE) {
-    makeVector_batchIdx = last_batchIdx;
-    batchRdy = true;
-  }
+    // Apply shaping.
+    #if HAS_X_AXIS
+      if (shaping.x.ena) {
+        shaping.x.d_zi[shaping.zi_idx] = traj.x[makeVector_batchIdx];
+        traj.x[makeVector_batchIdx] *= shaping.x.Ai[0];
+        for (uint32_t i = 1U; i <= shaping.x.max_i; i++) {
+          const uint32_t udiffx = shaping.zi_idx - shaping.x.Ni[i];
+          traj.x[makeVector_batchIdx] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
+        }
+      }
 
-  if (++makeVector_idx == max_intervals) {
-    blockProcDn = true;
-    blockProcRdy = false;
-    makeVector_idx = 0;
-  }
+      #if HAS_Y_AXIS
+        if (shaping.y.ena) {
+          shaping.y.d_zi[shaping.zi_idx] = traj.y[makeVector_batchIdx];
+          traj.y[makeVector_batchIdx] *= shaping.y.Ai[0];
+          for (uint32_t i = 1U; i <= shaping.y.max_i; i++) {
+            const uint32_t udiffy = shaping.zi_idx - shaping.y.Ni[i];
+            traj.y[makeVector_batchIdx] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
+          }
+        }
+      #endif
+      if (++shaping.zi_idx == (FTM_ZMAX)) shaping.zi_idx = 0;
+    #endif
+
+    // Filled up the queue with regular and shaped steps
+    if (++makeVector_batchIdx == FTM_WINDOW_SIZE) {
+      makeVector_batchIdx = BATCH_SIDX_IN_WINDOW;
+      batchRdy = true;
+    }
+
+    if (++makeVector_idx == max_intervals) {
+      if (traj_gen_cfg.mode) SERIAL_ECHOLN("M494 echo: profile ran to completion.");
+      blockProcRdy = false; traj_gen_cfg.mode = trajGenMode_NONE;
+      makeVector_idx = 0;
+    }
+  } while ((blockProcRdy || traj_gen_cfg.mode) && !batchRdy);
 }
 
 /**

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -26,35 +26,19 @@
 
 #include "ft_types.h"
 
-#if HAS_X_AXIS && (HAS_Z_AXIS || HAS_EXTRUDERS)
-  #define HAS_DYNAMIC_FREQ 1
-  #if HAS_Z_AXIS
-    #define HAS_DYNAMIC_FREQ_MM 1
-  #endif
-  #if HAS_EXTRUDERS
-    #define HAS_DYNAMIC_FREQ_G 1
-  #endif
-#endif
 
 typedef struct FTConfig {
   ftMotionMode_t mode = FTM_DEFAULT_MODE;                 // Mode / active compensation mode configuration.
 
-  bool modeHasShaper() { return WITHIN(mode, 10U, 19U); }
-
   #if HAS_X_AXIS
+    ftMotionCmpnstr_t cmpnstr[1 + ENABLED(HAS_Y_AXIS)] =               // Compensation mode.
+      { FTM_DEFAULT_X_COMPENSATOR OPTARG(HAS_Y_AXIS, FTM_DEFAULT_Y_COMPENSATOR) };
     float baseFreq[1 + ENABLED(HAS_Y_AXIS)] =             // Base frequency. [Hz]
       { FTM_SHAPING_DEFAULT_X_FREQ OPTARG(HAS_Y_AXIS, FTM_SHAPING_DEFAULT_Y_FREQ) };
     float zeta[1 + ENABLED(HAS_Y_AXIS)] =                 // Damping factor
-        { FTM_SHAPING_ZETA_X OPTARG(HAS_Y_AXIS, FTM_SHAPING_ZETA_Y) };
+        { FTM_SHAPING_DEFAULT_ZETA_X OPTARG(HAS_Y_AXIS, FTM_SHAPING_DEFAULT_ZETA_Y) };
     float vtol[1 + ENABLED(HAS_Y_AXIS)] =                 // Vibration Level
-        { FTM_SHAPING_V_TOL_X OPTARG(HAS_Y_AXIS, FTM_SHAPING_V_TOL_Y) };
-  #endif
-
-#if HAS_DYNAMIC_FREQ
-    dynFreqMode_t dynFreqMode = FTM_DEFAULT_DYNFREQ_MODE; // Dynamic frequency mode configuration.
-    float dynFreqK[1 + ENABLED(HAS_Y_AXIS)] = { 0.0f };   // Scaling / gain for dynamic frequency. [Hz/mm] or [Hz/g]
-  #else
-    static constexpr dynFreqMode_t dynFreqMode = dynFreqMode_DISABLED;
+        { FTM_SHAPING_DEFAULT_V_TOL_X OPTARG(HAS_Y_AXIS, FTM_SHAPING_DEFAULT_V_TOL_Y) };
   #endif
 
   #if HAS_EXTRUDERS
@@ -69,24 +53,23 @@ class FTMotion {
 
     // Public variables
     static ft_config_t cfg;
+    static ftMotionTrajGenConfig_t traj_gen_cfg;
     static bool busy;
 
     static void set_defaults() {
       cfg.mode = FTM_DEFAULT_MODE;
 
+      TERN_(HAS_X_AXIS, cfg.cmpnstr[X_AXIS] = FTM_DEFAULT_X_COMPENSATOR);
+      TERN_(HAS_Y_AXIS, cfg.cmpnstr[Y_AXIS] = FTM_DEFAULT_Y_COMPENSATOR);
+
       TERN_(HAS_X_AXIS, cfg.baseFreq[X_AXIS] = FTM_SHAPING_DEFAULT_X_FREQ);
       TERN_(HAS_Y_AXIS, cfg.baseFreq[Y_AXIS] = FTM_SHAPING_DEFAULT_Y_FREQ);
 
-      TERN_(HAS_X_AXIS, cfg.zeta[X_AXIS] = FTM_SHAPING_ZETA_X);
-      TERN_(HAS_Y_AXIS, cfg.zeta[Y_AXIS] = FTM_SHAPING_ZETA_Y);
+      TERN_(HAS_X_AXIS, cfg.zeta[X_AXIS] = FTM_SHAPING_DEFAULT_ZETA_X);
+      TERN_(HAS_Y_AXIS, cfg.zeta[Y_AXIS] = FTM_SHAPING_DEFAULT_ZETA_Y);
 
-      TERN_(HAS_X_AXIS, cfg.vtol[X_AXIS] = FTM_SHAPING_V_TOL_X);
-      TERN_(HAS_Y_AXIS, cfg.vtol[Y_AXIS] = FTM_SHAPING_V_TOL_Y);
-
-      #if HAS_DYNAMIC_FREQ
-        cfg.dynFreqMode = FTM_DEFAULT_DYNFREQ_MODE;
-        cfg.dynFreqK[X_AXIS] = TERN_(HAS_Y_AXIS, cfg.dynFreqK[Y_AXIS]) = 0.0f;
-      #endif
+      TERN_(HAS_X_AXIS, cfg.vtol[X_AXIS] = FTM_SHAPING_DEFAULT_V_TOL_X);
+      TERN_(HAS_Y_AXIS, cfg.vtol[Y_AXIS] = FTM_SHAPING_DEFAULT_V_TOL_Y);
 
       #if HAS_EXTRUDERS
         cfg.linearAdvEna = FTM_LINEAR_ADV_DEFAULT_ENA;
@@ -94,8 +77,7 @@ class FTMotion {
       #endif
 
       #if HAS_X_AXIS
-        refreshShapingN();
-        updateShapingA();
+        update_shaping_params();
       #endif
 
       reset();
@@ -107,37 +89,32 @@ class FTMotion {
 
     static bool sts_stepperBusy;                          // The stepper buffer has items and is in use.
 
+    static millis_t axis_pos_move_end_ti[NUM_AXIS_ENUMS],
+                    axis_neg_move_end_ti[NUM_AXIS_ENUMS];
+
     // Public methods
     static void init();
-    static void startBlockProc();                         // Set controller states to begin processing a block.
-    static bool getBlockProcDn() { return blockProcDn; }  // Return true if the controller no longer needs the current block.
-    static void runoutBlock();                            // Move any free data points to the stepper buffer even if a full batch isn't ready.
     static void loop();                                   // Controller main, to be invoked from non-isr task.
 
     #if HAS_X_AXIS
-      // Refresh the gains used by shaping functions.
-      // To be called on init or mode or zeta change.
-      static void updateShapingA(float zeta[]=cfg.zeta, float vtol[]=cfg.vtol);
-
-      // Refresh the indices used by shaping functions.
-      // To be called when frequencies change.
-      static void updateShapingN(const_float_t xf OPTARG(HAS_Y_AXIS, const_float_t yf), float zeta[]=cfg.zeta);
-
-      static void refreshShapingN() { updateShapingN(cfg.baseFreq[X_AXIS] OPTARG(HAS_Y_AXIS, cfg.baseFreq[Y_AXIS])); }
-
+      // Refreshes the gains and indices used by shaping functions.
+      static void update_shaping_params(void);
     #endif
 
     static void reset();                                  // Reset all states of the fixed time conversion to defaults.
+
+    static void setup_traj_gen(uint32_t intervals);
+
+    static bool axis_moving_pos(const AxisEnum axis) { return !ELAPSED(millis(), axis_pos_move_end_ti[axis]); }
+    static bool axis_moving_neg(const AxisEnum axis) { return !ELAPSED(millis(), axis_neg_move_end_ti[axis]); }
 
   private:
 
     static xyze_trajectory_t traj;
     static xyze_trajectoryMod_t trajMod;
 
-    static bool blockProcRdy, blockProcRdy_z1, blockProcDn;
+    static bool blockProcRdy;
     static bool batchRdy, batchRdyForInterp;
-    static bool runoutEna;
-    static bool blockDataIsRunout;
 
     // Trapezoid data variables.
     static xyze_pos_t   startPosn,          // (mm) Start position of block
@@ -152,19 +129,14 @@ class FTMotion {
     static uint32_t N1, N2, N3;
     static uint32_t max_intervals;
 
-    #define _DIVCEIL(A,B) (((A) + (B) - 1) / (B))
-    static constexpr uint32_t _ftm_ratio = TERN(FTM_UNIFIED_BWS, 2, _DIVCEIL(FTM_WINDOW_SIZE, FTM_BATCH_SIZE)),
-                              shaper_intervals = (FTM_BATCH_SIZE) * _DIVCEIL(FTM_ZMAX, FTM_BATCH_SIZE),
-                              min_max_intervals = (FTM_BATCH_SIZE) * _ftm_ratio;
+    static constexpr uint32_t PROP_BATCHES = CEIL(FTM_WINDOW_SIZE/FTM_BATCH_SIZE) - 1; // Number of batches needed to propagate the current trajectory to the stepper.
 
     // Make vector variables.
     static uint32_t makeVector_idx,
-                    makeVector_idx_z1,
                     makeVector_batchIdx;
 
     // Interpolation variables.
-    static uint32_t interpIdx,
-                    interpIdx_z1;
+    static uint32_t interpIdx;
 
     static xyze_long_t steps;
 
@@ -172,23 +144,23 @@ class FTMotion {
     #if HAS_X_AXIS
 
       typedef struct AxisShaping {
-        float d_zi[FTM_ZMAX] = { 0.0f };  // Data point delay vector.
+        bool ena;                         // Enabled indication.
+        float d_zi[FTM_ZMAX];             // Data point delay vector.
         float Ai[5];                      // Shaping gain vector.
         uint32_t Ni[5];                   // Shaping time index vector.
+        uint32_t max_i;                   // Vector length for the selected shaper.
 
-        void updateShapingN(const_float_t f, const_float_t df);
+        void set_axis_shaping_N(const ftMotionCmpnstr_t shaper, const_float_t f, const_float_t zeta);    // Sets the gains used by shaping functions.
+        void set_axis_shaping_A(const ftMotionCmpnstr_t shaper, const_float_t zeta, const_float_t vtol); // Sets the indices used by shaping functions.
 
       } axis_shaping_t;
 
       typedef struct Shaping {
-        uint32_t zi_idx,           // Index of storage in the data point delay vectors.
-                 max_i;            // Vector length for the selected shaper.
+        uint32_t zi_idx;           // Index of storage in the data point delay vectors.   
         axis_shaping_t x;
         #if HAS_Y_AXIS
           axis_shaping_t y;
         #endif
-
-        void updateShapingA(float zeta[]=cfg.zeta, float vtol[]=cfg.vtol);
 
       } shaping_t;
 
@@ -202,10 +174,15 @@ class FTMotion {
     #endif
 
     // Private methods
+    static void discard_planner_block_protected();
+    static void runoutBlock();
     static int32_t stepperCmdBuffItems();
     static void loadBlockData(block_t *const current_block);
     static void makeVector();
     static void convertToSteps(const uint32_t idx);
+
+    FORCE_INLINE static int32_t num_samples_cmpnstr_settle() { return ( shaping.x.ena || shaping.y.ena ) ? FTM_ZMAX : 0; }
+
 
 }; // class FTMotion
 

--- a/Marlin/src/module/ft_types.h
+++ b/Marlin/src/module/ft_types.h
@@ -25,24 +25,48 @@
 
 typedef enum FXDTICtrlMode : uint8_t {
   ftMotionMode_DISABLED   =  0, // Standard Motion
-  ftMotionMode_ENABLED    =  1, // Time-Based Motion
-  ftMotionMode_ZV         = 10, // Zero Vibration
-  ftMotionMode_ZVD        = 11, // Zero Vibration and Derivative
-  ftMotionMode_ZVDD       = 12, // Zero Vibration, Derivative, and Double Derivative
-  ftMotionMode_ZVDDD      = 13, // Zero Vibration, Derivative, Double Derivative, and Triple Derivative
-  ftMotionMode_EI         = 14, // Extra-Intensive
-  ftMotionMode_2HEI       = 15, // 2-Hump Extra-Intensive
-  ftMotionMode_3HEI       = 16, // 3-Hump Extra-Intensive
-  ftMotionMode_MZV        = 17  // Mass-based Zero Vibration
+  ftMotionMode_ENABLED    =  1  // Time-Based Motion
 } ftMotionMode_t;
 
-enum dynFreqMode_t : uint8_t {
-  dynFreqMode_DISABLED   = 0,
-  dynFreqMode_Z_BASED    = 1,
-  dynFreqMode_MASS_BASED = 2
-};
+typedef enum FXDTICtrlCmpnstr : uint8_t {
+  ftMotionCmpnstr_NONE       = 0, // No compensator
+  ftMotionCmpnstr_ZV         = 1, // Zero Vibration
+  ftMotionCmpnstr_ZVD        = 2, // Zero Vibration and Derivative
+  ftMotionCmpnstr_ZVDD       = 3, // Zero Vibration, Derivative, and Double Derivative
+  ftMotionCmpnstr_ZVDDD      = 4, // Zero Vibration, Derivative, Double Derivative, and Triple Derivative
+  ftMotionCmpnstr_EI         = 5, // Extra-Intensive
+  ftMotionCmpnstr_2HEI       = 6, // 2-Hump Extra-Intensive
+  ftMotionCmpnstr_3HEI       = 7, // 3-Hump Extra-Intensive
+  ftMotionCmpnstr_MZV        = 8  // Modified Zero Vibration
+} ftMotionCmpnstr_t;
 
-#define IS_EI_MODE(N) WITHIN(N, ftMotionMode_EI, ftMotionMode_3HEI)
+typedef enum FXDTICtrlTrajGenMode : uint8_t {
+  trajGenMode_NONE       =  0U,
+  trajGenMode_SWEEPC_X   =  1U,
+  trajGenMode_SWEEPC_Y   =  2U,
+  trajGenMode_ABORT      = 99U,
+} ftMotionTrajGenMode_t;
+
+typedef struct FXDTICtrlTrajGenConfig {
+  ftMotionTrajGenMode_t mode = trajGenMode_NONE;
+  float f0 = 0.0f,
+        f1 = 0.0f,
+        dfdt = 0.0f,
+        a = 0.0f,
+        pcws_ti[6] = {0.0f},
+        k1 = 0.0f,
+        k2 = 0.0f,
+        step_ti = 0.0f,
+        step_a = 0.0f,
+        dly1_ti = 0.0f,
+        dly2_ti = 0.0f,
+        dly3_ti = 0.0f,
+        step_a_x_0p5 = 0.0f,
+        step_a_x_step_ti_x_step_ti = 0.0f,
+        step_ti_x_2 = 0.0f,
+        step_ti_x_3 = 0.0f,
+        step_ti_x_4 = 0.0f;
+} ftMotionTrajGenConfig_t;
 
 typedef struct XYZEarray<float, FTM_WINDOW_SIZE> xyze_trajectory_t;
 typedef struct XYZEarray<float, FTM_BATCH_SIZE> xyze_trajectoryMod_t;

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -654,8 +654,6 @@ class Stepper {
     }
 
     #if ENABLED(FT_MOTION)
-      // Manage the planner
-      static void ftMotion_blockQueueUpdate();
       // Set current position in steps when reset flag is set in M493 and planner already synchronized
       static void ftMotion_syncPosition();
     #endif


### PR DESCRIPTION
This is a merge of previously shared firmware (https://github.com/S2AUlendo/Taz/commits/main/@a9d203a) into LulzBot3D's 2.1.3.0.30 Marlin tag (https://github.com/lulzbot3d/Marlin/commits/main/@c886c1c). This pull request will:

- Add autocalibration support features for Fixed Time Motion (FTM).
- Configure FTM to be available, but disabled (dormant).
- Configure buffers to allow for smooth printing using FTM and a host.