### PR TITLE
Add autocalibration feature to FTM

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -7,12 +7,12 @@
 
 /************** Uncomment a Tool Head Option From Below *********************/
 
-//#define TOOLHEAD_Legacy_Universal
-#define TOOLHEAD_Galaxy_Series
+#define TOOLHEAD_Legacy_Universal
+// #define TOOLHEAD_Galaxy_Series
 //#define TOOLHEAD_SL_SE_HE
 //#define TOOLHEAD_HS_HSPLUS
 //#define TOOLHEAD_H175
-//#define TOOLHEAD_M175
+#define TOOLHEAD_M175
 //#define TOOLHEAD_SK175
 //#define TOOLHEAD_SK285
 //#define TOOLHEAD_Quiver_DualExtruder            // TAZ Pro Dual Extruder

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1154,7 +1154,7 @@
  * Enable/disable and set parameters with G-code M493.
  * See ft_types.h for named values used by FTM options.
  */
-//#define FT_MOTION
+#define FT_MOTION
 #if ENABLED(FT_MOTION)
   //#define FTM_IS_DEFAULT_MOTION                 // Use FT Motion as the factory default?
   #define FTM_DEFAULT_DYNFREQ_MODE dynFreqMode_DISABLED // Default mode of dynamic frequency calculation. (DISABLED, Z_BASED, MASS_BASED)
@@ -1187,11 +1187,11 @@
   #define FTM_TS                        0.001f    // (s) Time step for trajectory generation. (Reciprocal of FTM_FS)
 
   #if DISABLED(COREXY)
-    #define FTM_STEPPER_FS          20000         // (Hz) Frequency for stepper I/O update
+    #define FTM_STEPPER_FS          40000         // (Hz) Frequency for stepper I/O update
 
     // Use this to adjust the time required to consume the command buffer.
     // Try increasing this value if stepper motion is choppy.
-    #define FTM_STEPPERCMD_BUFF_SIZE 3000         // Size of the stepper command buffers
+    #define FTM_STEPPERCMD_BUFF_SIZE 12000         // Size of the stepper command buffers
 
   #else
     // CoreXY motion needs a larger buffer size. These values are based on our testing.
@@ -1310,9 +1310,9 @@
 #define SLOWDOWN
 #if ENABLED(SLOWDOWN)
   #if ANY(TAZPro, TAZProXT, TAXProV2)
-    #define SLOWDOWN_DIVISOR 16
+    #define SLOWDOWN_DIVISOR 2
   #else
-    #define SLOWDOWN_DIVISOR 8
+    #define SLOWDOWN_DIVISOR 2
   #endif
 #endif
 
@@ -2754,7 +2754,7 @@
 // @section motion
 
 // Moves (or segments) with fewer steps than this will be joined with the next move
-#define MIN_STEPS_PER_SEGMENT 6
+#define MIN_STEPS_PER_SEGMENT 15
 
 /**
  * Minimum delay before and after setting the stepper DIR (in ns)
@@ -2813,11 +2813,11 @@
 
 // The number of linear moves that can be in the planner at once.
 #if ALL(HAS_MEDIA, DIRECT_STEPPING)
-  #define BLOCK_BUFFER_SIZE  8
+  #define BLOCK_BUFFER_SIZE 64
 #elif HAS_MEDIA
-  #define BLOCK_BUFFER_SIZE 16
+  #define BLOCK_BUFFER_SIZE 64
 #else
-  #define BLOCK_BUFFER_SIZE 16
+  #define BLOCK_BUFFER_SIZE 64
 #endif
 
 // @section serial
@@ -2825,9 +2825,9 @@
 // The ASCII buffer for serial input
 #define MAX_CMD_SIZE 96
 #if ANY(TAZPro, TAZProXT, TAXProV2)
-  #define BUFSIZE 16
+  #define BUFSIZE 64
 #else
-  #define BUFSIZE 8
+  #define BUFSIZE 64
 #endif
 
 // Transmission to Host Buffer Size
@@ -2843,7 +2843,7 @@
 // Without XON/XOFF flow control (see SERIAL_XON_XOFF below) 32 bytes should be enough.
 // To use flow control, set this buffer size to at least 1024 bytes.
 // :[0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
-//#define RX_BUFFER_SIZE 1024
+#define RX_BUFFER_SIZE 2048
 
 #if RX_BUFFER_SIZE >= 1024
   // Enable to have the controller send XON/XOFF control characters to

--- a/Marlin/src/gcode/feature/ft_motion/M494.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M494.cpp
@@ -1,0 +1,211 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if ENABLED(FT_MOTION)
+
+#include "../../gcode.h"
+#include "../../../module/ft_motion.h"
+#include "../../../module/stepper.h"
+
+
+void say_ftm_cfg() {
+  #if ENABLED(FTM_UNIFIED_BWS)
+    SERIAL_ECHOPGM( "M494 FTMCFG FTM_BATCH_SIZE:", (int)(FTM_BW_SIZE),
+                    " FTM_WINDOW_SIZE:", (int)(FTM_BW_SIZE));
+  #else
+    SERIAL_ECHOPGM( "M494 FTMCFG FTM_BATCH_SIZE:", (int)(FTM_BATCH_SIZE),
+                    " FTM_WINDOW_SIZE:", (int)(FTM_WINDOW_SIZE));
+  #endif
+  SERIAL_ECHOPGM( " FTM_FS:", (int)(FTM_FS),
+                  " FTM_STEPPER_FS:", (int)(FTM_STEPPER_FS),
+                  " FTM_STEPPERCMD_BUFF_SIZE:", (int)(FTM_STEPPERCMD_BUFF_SIZE),
+                  " STEPPER_TIMER_RATE:", (int)(STEPPER_TIMER_RATE),
+                  " FTM_ZMAX:", (int)(FTM_ZMAX),
+                  " X_MAX_LENGTH:", (int)(X_MAX_LENGTH));
+  #if HAS_Y_AXIS
+    SERIAL_ECHOPGM( " Y_MAX_LENGTH:", (int)(Y_MAX_LENGTH));
+  #endif
+  SERIAL_EOL();
+}
+
+
+/**
+ * M494: Interact with Fixed-time Motion Control's trajectory generation.
+ *
+ *    A<mode> Start / abort a frequency sweep profile.
+ *
+ *       0: None active.
+ *       1: Continuous sweep on X axis.
+ *       2: Continuous sweep on Y axis.
+ *       99: Abort the current sweep.
+ * 
+ *    B<float> Start frequency.
+ *    C<float> End frequency.
+ *    D<float> Frequency rate.
+ *    E<float> Acceleration amplitude.
+ *    F<float> Step time.
+ *    H<float> Step acceleration amplitude.
+ *    I<float> Delay time to opening step.
+ *    J<float> Delay time from opening step to sweep.
+ *    K<float> Delay time from sweep to closing step.
+ * 
+ * With no parameters passed, M494 will report the FTM configuration and
+ * variables required for autocalibration.
+ * 
+ */
+void GcodeSuite::M494() {
+  
+  if (!parser.seen_any()) { say_ftm_cfg(); return; }
+
+  if (!ftMotion.cfg.active) { SERIAL_ECHOLN("M494 echo: rejected! FTM is not enabled."); return; }
+
+  ftMotionTrajGenMode_t mode_val_seen = trajGenMode_NONE;
+  bool good_cfg_received = true;
+
+  // Parse mode parameter.
+  if (parser.seenval('A')) {
+    const ftMotionTrajGenMode_t newmm = (ftMotionTrajGenMode_t)parser.value_byte();
+    switch (newmm) {
+      default: SERIAL_ECHOLNPGM("?Invalid calibration mode [F] value."); return;
+      case trajGenMode_NONE:
+      case trajGenMode_SWEEPC_X:
+      #if HAS_Y_AXIS
+      case trajGenMode_SWEEPC_Y:
+      #endif
+        if ( ftMotion.traj_gen_cfg.mode ) {
+          SERIAL_ECHOLN("M494 echo: rejected! wait for the previous command to complete.");
+          return;
+        }
+        mode_val_seen = newmm;
+        break;
+      case trajGenMode_ABORT:
+        if ( ftMotion.traj_gen_cfg.mode ) {
+          ftMotion.traj_gen_cfg.mode = trajGenMode_NONE;
+          stepper.quick_stop();
+          return;
+        }
+    }
+  }
+
+  // Parse start frequency parameter.
+  if (parser.seenval('B')) {
+      const float val = parser.value_float();
+      if (val >= 1.0f) ftMotion.traj_gen_cfg.f0 = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Start frequency out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse end frequency parameter.
+  if (parser.seenval('C')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.f1 = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: End frequency out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse step frequency parameter.
+  if (parser.seenval('D')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dfdt = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Step / delta frequency out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse amplitude parameter.
+  if (parser.seenval('E')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.a = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Amplitude out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse step time parameter.
+  if (parser.seenval('F')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.step_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Step time out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse step amplitude parameter.
+  if (parser.seenval('H')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.step_a = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Step amplitude out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse delay parameter.
+  if (parser.seenval('I')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dly1_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Delay 1 out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse delay parameter.
+  if (parser.seenval('J')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dly2_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Delay 2 out of range."); }
+  } else good_cfg_received = false;
+
+  // Parse delay parameter.
+  if (parser.seenval('K')) {
+      const float val = parser.value_float();
+      if (val > 0.0f) ftMotion.traj_gen_cfg.dly3_ti = val;
+      else { good_cfg_received = false; SERIAL_ECHOLN("M494 echo: Delay 3 out of range."); }
+  } else good_cfg_received = false;
+
+  // Validate and set.
+  if ( mode_val_seen && good_cfg_received ) {
+
+    planner.synchronize();
+
+    const float f0_ = ftMotion.traj_gen_cfg.f0 - 1.f; // This is calculated assuming a ramp time of 1 sec.
+
+    ftMotion.traj_gen_cfg.k1 = PI*ftMotion.traj_gen_cfg.dfdt;
+    ftMotion.traj_gen_cfg.k2 = 2.f*PI*f0_;
+
+    ftMotion.traj_gen_cfg.pcws_ti[0] = ftMotion.traj_gen_cfg.dly1_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[1] = ftMotion.traj_gen_cfg.pcws_ti[0] + 4 * ftMotion.traj_gen_cfg.step_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[2] = ftMotion.traj_gen_cfg.pcws_ti[1] + ftMotion.traj_gen_cfg.dly2_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[3] = ftMotion.traj_gen_cfg.pcws_ti[2] + ( ftMotion.traj_gen_cfg.f1 - f0_ ) / ftMotion.traj_gen_cfg.dfdt;
+    ftMotion.traj_gen_cfg.pcws_ti[4] = ftMotion.traj_gen_cfg.pcws_ti[3] + ftMotion.traj_gen_cfg.dly3_ti;
+    ftMotion.traj_gen_cfg.pcws_ti[5] = ftMotion.traj_gen_cfg.pcws_ti[4] + 4 * ftMotion.traj_gen_cfg.step_ti;
+
+    ftMotion.traj_gen_cfg.step_a_x_0p5 = 0.5f * ftMotion.traj_gen_cfg.step_a;
+    ftMotion.traj_gen_cfg.step_a_x_step_ti_x_step_ti = ftMotion.traj_gen_cfg.step_a * sq(ftMotion.traj_gen_cfg.step_ti);
+    ftMotion.traj_gen_cfg.step_ti_x_2 = 2.f * ftMotion.traj_gen_cfg.step_ti;
+    ftMotion.traj_gen_cfg.step_ti_x_3 = 3.f * ftMotion.traj_gen_cfg.step_ti;
+    ftMotion.traj_gen_cfg.step_ti_x_4 = 4.f * ftMotion.traj_gen_cfg.step_ti;
+
+    ftMotion.traj_gen_cfg.mode = mode_val_seen;
+
+    ftMotion.setup_traj_gen(round(ftMotion.traj_gen_cfg.pcws_ti[5]*FTM_FS + 0.5f));
+
+    SERIAL_ECHOLN("M494 echo: SWEEPC starting.");
+
+    stepper.enable_all_steppers();
+
+    // stepper.disable_all_steppers(); Leave this to the plugin or user; this can
+    // be annoying on printers that require all axes homing before axis movement.
+  }
+
+}
+
+#endif // FT_MOTION

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -920,6 +920,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
       #if ENABLED(FT_MOTION)
         case 493: M493(); break;                                  // M493: Fixed-Time Motion control
+        case 494: M494(); break;                                  // M494: Fixed-Time Motion control trajectory generation
       #endif
 
       case 500: M500(); break;                                    // M500: Store settings in EEPROM

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -1090,6 +1090,7 @@ private:
   #if ENABLED(FT_MOTION)
     static void M493();
     static void M493_report(const bool forReplay=true);
+    static void M494();
   #endif
 
   static void M500();

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -70,6 +70,7 @@ class FTMotion {
 
     // Public variables
     static ft_config_t cfg;
+    static ftMotionTrajGenConfig_t traj_gen_cfg;
     static bool busy;
 
     static void set_defaults() {
@@ -129,6 +130,8 @@ class FTMotion {
 
     static void reset();                                  // Reset all states of the fixed time conversion to defaults.
 
+	static void setup_traj_gen(uint32_t intervals);
+	
     FORCE_INLINE static bool axis_is_moving(const AxisEnum axis) {
       return cfg.active ? PENDING(millis(), axis_move_end_ti[axis]) : stepper.axis_is_moving(axis);
     }
@@ -173,8 +176,8 @@ class FTMotion {
     #if HAS_FTM_SHAPING
 
       typedef struct AxisShaping {
-        bool ena = false;                 // Enabled indication.
-        float d_zi[FTM_ZMAX] = { 0.0f };  // Data point delay vector.
+        bool ena;                         // Enabled indication.
+        float d_zi[FTM_ZMAX];             // Data point delay vector.
         float Ai[5];                      // Shaping gain vector.
         uint32_t Ni[5];                   // Shaping time index vector.
         uint32_t max_i;                   // Vector length for the selected shaper.

--- a/Marlin/src/module/ft_types.h
+++ b/Marlin/src/module/ft_types.h
@@ -35,6 +35,34 @@ enum ftMotionShaper_t : uint8_t {
   ftMotionShaper_MZV   = 8  // Modified Zero Vibration
 };
 
+typedef enum FXDTICtrlTrajGenMode : uint8_t {
+  trajGenMode_NONE       =  0U,
+  trajGenMode_SWEEPC_X   =  1U,
+  trajGenMode_SWEEPC_Y   =  2U,
+  trajGenMode_ABORT      = 99U,
+} ftMotionTrajGenMode_t;
+
+typedef struct FXDTICtrlTrajGenConfig {
+  ftMotionTrajGenMode_t mode = trajGenMode_NONE;
+  float f0 = 0.0f,
+        f1 = 0.0f,
+        dfdt = 0.0f,
+        a = 0.0f,
+        pcws_ti[6] = {0.0f},
+        k1 = 0.0f,
+        k2 = 0.0f,
+        step_ti = 0.0f,
+        step_a = 0.0f,
+        dly1_ti = 0.0f,
+        dly2_ti = 0.0f,
+        dly3_ti = 0.0f,
+        step_a_x_0p5 = 0.0f,
+        step_a_x_step_ti_x_step_ti = 0.0f,
+        step_ti_x_2 = 0.0f,
+        step_ti_x_3 = 0.0f,
+        step_ti_x_4 = 0.0f;
+} ftMotionTrajGenConfig_t;
+
 enum dynFreqMode_t : uint8_t {
   dynFreqMode_DISABLED   = 0,
   dynFreqMode_Z_BASED    = 1,


### PR DESCRIPTION
Updates pertaining to fixed-time-motion.
- Enables FTM in compilation but sets its mode disabled (dormant).
- Adds autocalibration support for FTM.
- Configures buffers working for printing on the Taz Pro via a host.